### PR TITLE
feat: Add overlay to display connection warning messages while streaming

### DIFF
--- a/wasm/connectionlistener.cpp
+++ b/wasm/connectionlistener.cpp
@@ -55,6 +55,21 @@ void MoonlightInstance::ClLogMessage(const char* format, ...) {
   emscripten_log(EM_LOG_CONSOLE, "%s", message);
 }
 
+void MoonlightInstance::ClConnectionStatusUpdate(int connectionStatus) {
+  if (g_Instance->m_DisableWarningsEnabled == false) {
+    switch (connectionStatus) {
+      case CONN_STATUS_OKAY:
+        PostToJs(std::string("NoWarningMsg: ") + std::string("Connection to PC has been improved."));
+        break;
+      case CONN_STATUS_POOR:
+        PostToJs(std::string("WarningMsg: ") + std::string("Slow connection to PC.\nReduce your bitrate!"));
+        break;
+      default:
+        break;
+    }
+  }
+}
+
 CONNECTION_LISTENER_CALLBACKS MoonlightInstance::s_ClCallbacks = {
   .stageStarting = MoonlightInstance::ClStageStarting,
   .stageFailed = MoonlightInstance::ClStageFailed,
@@ -62,4 +77,5 @@ CONNECTION_LISTENER_CALLBACKS MoonlightInstance::s_ClCallbacks = {
   .connectionTerminated = MoonlightInstance::ClConnectionTerminated,
   .logMessage = MoonlightInstance::ClLogMessage,
   .rumble = MoonlightInstance::ClControllerRumble,
+  .connectionStatusUpdate = MoonlightInstance::ClConnectionStatusUpdate,
 };

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -375,6 +375,7 @@
         <h4 id="loadingSpinnerMessage"></h4>
       </div>
     </main>
+    <div id="connection-warnings"></div>
   </div>
   <script defer src="static/js/jquery-2.2.0.min.js"></script>
   <script defer src="static/js/material.min.js"></script>

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -306,6 +306,16 @@
                 </label>
               </div>
             </div>
+            <div class="setting-option">
+              <label>Connection warnings</label>
+              <span class="mdl-list__item-text-body"></span>
+              <div id="connectionWarningsMenu">
+                <label id="disableWarningsBtn" class="mdl-switch mdl-js-switch mdl-js-ripple-effect" for="disableWarningsSwitch">
+                  <input type="checkbox" id="disableWarningsSwitch" class="mdl-switch__input">
+                  <span class="mdl-switch__label">Disable on-screen connection warning messages while streaming</span>
+                </label>
+              </div>
+            </div>
           </div>
           <div id="aboutSettings" class="settings-options">
             <div class="setting-option">

--- a/wasm/main.cpp
+++ b/wasm/main.cpp
@@ -210,7 +210,7 @@ static void HexStringToBytes(const char* str, char* output) {
 MessageResult MoonlightInstance::StartStream(std::string host, std::string width, std::string height, std::string fps, std::string bitrate,
   std::string rikey, std::string rikeyid, std::string appversion, std::string gfeversion, std::string rtspurl, int serverCodecModeSupport,
   bool framePacing, bool optimizeGames, bool playHostAudio, bool rumbleFeedback, bool mouseEmulation, bool flipABfaceButtons, bool flipXYfaceButtons,
-  std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange) {
+  std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange, bool disableWarnings) {
   PostToJs("Setting the Host address to: " + host);
   PostToJs("Setting the Video resolution to: " + width + "x" + height);
   PostToJs("Setting the Video frame rate to: " + fps + " FPS");
@@ -233,6 +233,7 @@ MessageResult MoonlightInstance::StartStream(std::string host, std::string width
   PostToJs("Setting the Video codec to: " + videoCodec);
   PostToJs("Setting the Video HDR mode to: " + std::to_string(hdrMode));
   PostToJs("Setting the Full color range to: " + std::to_string(fullRange));
+  PostToJs("Setting the Disable connection warnings to: " + std::to_string(disableWarnings));
 
   // Populate the stream configuration
   LiInitializeStreamConfiguration(&m_StreamConfig);
@@ -331,6 +332,7 @@ MessageResult MoonlightInstance::StartStream(std::string host, std::string width
   m_AudioSyncEnabled = audioSync;
   m_HdrModeEnabled = hdrMode;
   m_FullRangeEnabled = fullRange;
+  m_DisableWarningsEnabled = disableWarnings;
 
   // Initialize the rendering surface before starting the connection
   if (InitializeRenderingSurface(m_StreamConfig.width, m_StreamConfig.height)) {
@@ -471,11 +473,11 @@ int main(int argc, char** argv) {
 MessageResult startStream(std::string host, std::string width, std::string height, std::string fps, std::string bitrate,
   std::string rikey, std::string rikeyid, std::string appversion, std::string gfeversion, std::string rtspurl, int serverCodecModeSupport,
   bool framePacing, bool optimizeGames, bool playHostAudio, bool rumbleFeedback, bool mouseEmulation, bool flipABfaceButtons, bool flipXYfaceButtons,
-  std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange) {
+  std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange, bool disableWarnings) {
   PostToJs("Starting the streaming session...");
   return g_Instance->StartStream(host, width, height, fps, bitrate, rikey, rikeyid, appversion, gfeversion, rtspurl, serverCodecModeSupport,
   framePacing, optimizeGames, playHostAudio, rumbleFeedback, mouseEmulation, flipABfaceButtons, flipXYfaceButtons, audioConfig,
-  audioSync, videoCodec, hdrMode, fullRange);
+  audioSync, videoCodec, hdrMode, fullRange, disableWarnings);
 }
 
 MessageResult stopStream() {

--- a/wasm/moonlight_wasm.hpp
+++ b/wasm/moonlight_wasm.hpp
@@ -114,6 +114,7 @@ class MoonlightInstance {
   static void ClDisplayTransientMessage(const char* message);
   static void ClLogMessage(const char* format, ...);
   static void ClControllerRumble(unsigned short controllerNumber, unsigned short lowFreqMotor, unsigned short highFreqMotor);
+  static void ClConnectionStatusUpdate(int connectionStatus);
 
   void DidChangeFocus(bool got_focus);
   bool InitializeRenderingSurface(int width, int height);

--- a/wasm/moonlight_wasm.hpp
+++ b/wasm/moonlight_wasm.hpp
@@ -63,7 +63,7 @@ class MoonlightInstance {
   MessageResult StartStream(std::string host, std::string width, std::string height, std::string fps, std::string bitrate,
     std::string rikey, std::string rikeyid, std::string appversion, std::string gfeversion, std::string rtspurl, int serverCodecModeSupport,
     bool framePacing, bool optimizeGames, bool playHostAudio, bool rumbleFeedback, bool mouseEmulation, bool flipABfaceButtons, bool flipXYfaceButtons,
-    std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange);
+    std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange, bool disableWarnings);
   MessageResult StopStream();
 
   void STUN(int callbackId);
@@ -199,6 +199,7 @@ class MoonlightInstance {
   int m_VideoCodec;
   bool m_HdrModeEnabled;
   bool m_FullRangeEnabled;
+  bool m_DisableWarningsEnabled;
 
   STREAM_CONFIGURATION m_StreamConfig;
   bool m_Running;
@@ -253,7 +254,7 @@ void openUrl(int callbackId, std::string url, emscripten::val ppk, bool binaryRe
 MessageResult startStream(std::string host, std::string width, std::string height, std::string fps, std::string bitrate,
   std::string rikey, std::string rikeyid, std::string appversion, std::string gfeversion, std::string rtspurl, int serverCodecModeSupport,
   bool framePacing, bool optimizeGames, bool playHostAudio, bool rumbleFeedback, bool mouseEmulation, bool flipABfaceButtons, bool flipXYfaceButtons,
-  std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange);
+  std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange, bool disableWarnings);
 MessageResult stopStream();
 
 void stun(int callbackId);

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -276,6 +276,7 @@ function showHostsMode() {
   $('#goBackBtn').hide();
   $('#restoreDefaultsBtn').hide();
   $('#quitRunningAppBtn').hide();
+  $('#connection-warnings').css('display', 'none');
   $('#main-content').removeClass('fullscreen');
   $('#listener').removeClass('fullscreen');
 
@@ -1090,6 +1091,7 @@ function showSettingsMode() {
   $('#settingsBtn').hide();
   $('#supportBtn').hide();
   $('#quitRunningAppBtn').hide();
+  $('#connection-warnings').css('display', 'none');
   $('#main-content').removeClass('fullscreen');
   $('#listener').removeClass('fullscreen');
 
@@ -1720,6 +1722,7 @@ function showAppsMode() {
   $('#settingsBtn').hide();
   $('#supportBtn').hide();
   $('#restoreDefaultsBtn').hide();
+  $('#connection-warnings').css('display', 'none');
   $('#main-content').removeClass('fullscreen');
   $('#listener').removeClass('fullscreen');
   $('#loadingSpinner').css('display', 'none');
@@ -1941,6 +1944,7 @@ function showStreamMode() {
 
   isInGame = true;
   fullscreenWasmModule();
+  handleOnScreenOverlays();
   Navigation.stop();
 }
 
@@ -1960,6 +1964,15 @@ function fullscreenWasmModule() {
   module.width = zoom * streamWidth;
   module.height = zoom * streamHeight;
   module.style.marginTop = ((screenHeight - module.height) / 2) + 'px';
+}
+
+// Handle on-screen overlays when the streaming session starts
+function handleOnScreenOverlays() {
+  // Find the existing toggle switch elements
+  const disableWarningsSwitch = document.getElementById('disableWarningsSwitch');
+
+  // Check if the disable warnings switch is checked, then hide or show the connection warning messages
+  disableWarningsSwitch.checked ? $('#connection-warnings').css('display', 'none') : $('#connection-warnings').css('display', 'inline-block');
 }
 
 // Start the given appID. If another app is running, offer to quit it. Otherwise, if the given app is already running, just resume it.
@@ -2058,6 +2071,9 @@ function startGame(host, appID) {
       '\n Video HDR mode: ' + hdrMode + 
       '\n Full color range: ' + fullRange + 
       '\n Disable connection warnings: ' + disableWarnings);
+
+      // Hide on-screen overlays until the streaming session begins
+      $('#connection-warnings').css('background', 'transparent').text('');
 
       // Shows a loading message to launch the application and start stream mode
       $('#loadingSpinnerMessage').text('Starting ' + appToStart.title + '...');

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -51,6 +51,7 @@ function attachListeners() {
   $('.videoCodecMenu li').on('click', saveVideoCodec);
   $('#hdrModeSwitch').on('click', saveHdrMode);
   $('#fullRangeSwitch').on('click', saveFullRange);
+  $('#disableWarningsSwitch').on('click', saveDisableWarnings);
   $('#navigationGuideBtn').on('click', navigationGuideDialog);
   $('#checkUpdatesBtn').on('click', checkForAppUpdates);
   $('#restartAppBtn').on('click', restartAppDialog);
@@ -2037,6 +2038,7 @@ function startGame(host, appID) {
       var videoCodec = $('#selectCodec').data('value').toString();
       const hdrMode = $('#hdrModeSwitch').parent().hasClass('is-checked') ? 1 : 0;
       const fullRange = $('#fullRangeSwitch').parent().hasClass('is-checked') ? 1 : 0;
+      const disableWarnings = $('#disableWarningsSwitch').parent().hasClass('is-checked') ? 1 : 0;
 
       console.log('%c[index.js, startGame]', 'color: green;', 'startRequest:' + 
       '\n Host address: ' + host.address + 
@@ -2054,7 +2056,8 @@ function startGame(host, appID) {
       '\n Audio synchronization: ' + audioSync + 
       '\n Video codec: ' + videoCodec + 
       '\n Video HDR mode: ' + hdrMode + 
-      '\n Full color range: ' + fullRange);
+      '\n Full color range: ' + fullRange + 
+      '\n Disable connection warnings: ' + disableWarnings);
 
       // Shows a loading message to launch the application and start stream mode
       $('#loadingSpinnerMessage').text('Starting ' + appToStart.title + '...');
@@ -2086,7 +2089,7 @@ function startGame(host, appID) {
             host.address, streamWidth, streamHeight, frameRate, bitrate.toString(), rikey, rikeyid.toString(),
             host.appVersion, host.gfeVersion, $root.find('sessionUrl0').text().trim(), host.serverCodecModeSupport,
             framePacing, optimizeGames, playHostAudio, rumbleFeedback, mouseEmulation, flipABfaceButtons, flipXYfaceButtons,
-            audioConfig, audioSync, videoCodec, hdrMode, fullRange
+            audioConfig, audioSync, videoCodec, hdrMode, fullRange, disableWarnings
           ]);
         }, function(failedResumeApp) {
           console.error('%c[index.js, startGame]', 'color: green;', 'Error: Failed to resume app with id: ' + appID + '\n Returned error was: ' + failedResumeApp + '!');
@@ -2126,7 +2129,7 @@ function startGame(host, appID) {
           host.address, streamWidth, streamHeight, frameRate, bitrate.toString(), rikey, rikeyid.toString(),
           host.appVersion, host.gfeVersion, $root.find('sessionUrl0').text().trim(), host.serverCodecModeSupport,
           framePacing, optimizeGames, playHostAudio, rumbleFeedback, mouseEmulation, flipABfaceButtons, flipXYfaceButtons,
-          audioConfig, audioSync, videoCodec, hdrMode, fullRange
+          audioConfig, audioSync, videoCodec, hdrMode, fullRange, disableWarnings
         ]);
       }, function(failedLaunchApp) {
         console.error('%c[index.js, startGame]', 'color: green;', 'Error: Failed to launch app with id: ' + appID + '\n Returned error was: ' + failedLaunchApp + '!');
@@ -2654,6 +2657,14 @@ function saveFullRange() {
   }, 100);
 }
 
+function saveDisableWarnings() {
+  setTimeout(() => {
+    const chosenDisableWarnings = $('#disableWarningsSwitch').parent().hasClass('is-checked');
+    console.log('%c[index.js, saveDisableWarnings]', 'color: green;', 'Saving disable warnings state: ' + chosenDisableWarnings);
+    storeData('disableWarnings', chosenDisableWarnings, null);
+  }, 100);
+}
+
 // Reset all settings to their default state and save the value data
 function restoreDefaultsSettingsValues() {
   const defaultResolution = '1280:720';
@@ -2724,6 +2735,10 @@ function restoreDefaultsSettingsValues() {
   const defaultFullRange = false;
   document.querySelector('#fullRangeBtn').MaterialSwitch.off();
   storeData('fullRange', defaultFullRange, null);
+
+  const defaultDisableWarnings = false;
+  document.querySelector('#disableWarningsBtn').MaterialSwitch.off();
+  storeData('disableWarnings', defaultDisableWarnings, null);
 }
 
 function initSamsungKeys() {
@@ -3002,6 +3017,17 @@ function loadUserDataCb() {
       document.querySelector('#fullRangeBtn').MaterialSwitch.off();
     } else {
       document.querySelector('#fullRangeBtn').MaterialSwitch.on();
+    }
+  });
+
+  console.log('%c[index.js, loadUserDataCb]', 'color: green;', 'Load stored disableWarnings preferences.');
+  getData('disableWarnings', function(previousValue) {
+    if (previousValue.disableWarnings == null) {
+      document.querySelector('#disableWarningsBtn').MaterialSwitch.off(); // Set the default state
+    } else if (previousValue.disableWarnings == false) {
+      document.querySelector('#disableWarningsBtn').MaterialSwitch.off();
+    } else {
+      document.querySelector('#disableWarningsBtn').MaterialSwitch.on();
     }
   });
 }

--- a/wasm/platform/messages.js
+++ b/wasm/platform/messages.js
@@ -72,6 +72,8 @@ function handleMessage(msg) {
   console.log('%c[messages.js, handleMessage]', 'color: gray;', 'Message data: ', msg);
   // If it's a recognized event, notify the appropriate function
   if (msg.indexOf('streamTerminated: ') === 0) {
+    // Remove the on-screen overlays
+    $('#connection-warnings').css('display', 'none');
     // Show a termination snackbar message if the termination was unexpected
     var errorCode = parseInt(msg.replace('streamTerminated: ', ''));
     switch (errorCode) {

--- a/wasm/platform/messages.js
+++ b/wasm/platform/messages.js
@@ -133,6 +133,14 @@ function handleMessage(msg) {
   } else if (msg === 'displayVideo') {
     // Show the video stream now
     $('#listener').addClass('fullscreen');
+  } else if (msg.indexOf('NoWarningMsg: ') === 0) {
+    // Hide the connection warnings overlay
+    $('#connection-warnings').css('background', 'transparent');
+    $('#connection-warnings').text('');
+  } else if (msg.indexOf('WarningMsg: ') === 0) {
+    // Show the connection warnings overlay
+    $('#connection-warnings').css('background', 'rgba(0, 0, 0, 0.5)');
+    $('#connection-warnings').text(msg.replace('WarningMsg: ', ''));
   } else if (msg.indexOf('controllerRumble: ') === 0) {
     const eventData = msg.split(' ')[1].split(',');
     const gamepadIdx = parseInt(eventData[0]);

--- a/wasm/platform/messages.js
+++ b/wasm/platform/messages.js
@@ -7,7 +7,7 @@ const SyncFunctions = {
   'httpInit': (...args) => Module.httpInit(...args),
   /* host, width, height, fps, bitrate, rikey, rikeyid, appversion, gfeversion, rtspurl, serverCodecModeSupport,
   framePacing, optimizeGames, playHostAudio, rumbleFeedback, mouseEmulation, flipABfaceButtons, flipXYfaceButtons,
-  audioConfig, audioSync, videoCodec, hdrMode, fullRange */
+  audioConfig, audioSync, videoCodec, hdrMode, fullRange, disableWarnings */
   'startRequest': (...args) => Module.startStream(...args),
   // no parameters
   'stopRequest': (...args) => Module.stopStream(...args),

--- a/wasm/platform/navigation.js
+++ b/wasm/platform/navigation.js
@@ -1035,7 +1035,8 @@ const Views = {
     view: new ListView(() => [
       'selectCodec',
       'hdrModeBtn',
-      'fullRangeBtn'
+      'fullRangeBtn',
+      'disableWarningsBtn'
     ]),
     up: function() {
       this.view.prevOption();

--- a/wasm/static/css/style.css
+++ b/wasm/static/css/style.css
@@ -652,12 +652,27 @@ body {
    Streaming Layout
 ============================= */
 .fullscreen {
+    position: relative !important;
     height: 100vh !important;
     z-index: 1 !important;
     margin: auto !important;
     padding: 0 !important;
     border: none !important;
     overflow: hidden !important;
+}
+#connection-warnings {
+    color: #fff;
+    background: transparent;
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    z-index: 3;
+    padding: 10px;
+    border-radius: 8px;
+    font-size: 2rem;
+    font-weight: 600;
+    line-height: 1.2;
+    white-space: pre-wrap;
 }
 /* =============================
    Settings Section

--- a/wasm/static/css/style.css
+++ b/wasm/static/css/style.css
@@ -826,7 +826,7 @@ body {
 #ipAddressFieldModeBtn, #sortAppsListBtn, #optimizeGamesBtn, #playHostAudioBtn,
 #removeAllHostsBtn, #rumbleFeedbackBtn, #mouseEmulationBtn, #flipABfaceButtonsBtn,
 #flipXYfaceButtonsBtn, #selectAudio, #audioSyncBtn, #selectCodec, #hdrModeBtn,
-#fullRangeBtn, #navigationGuideBtn, #checkUpdatesBtn, #restartAppBtn {
+#fullRangeBtn, #disableWarningsBtn, #navigationGuideBtn, #checkUpdatesBtn, #restartAppBtn {
     color: #ececec;
     background-color: #404354;
     width: 100%;
@@ -939,9 +939,9 @@ body {
 #optimizeGamesBtn:hover, #optimizeGamesBtn:focus, #playHostAudioBtn:hover, #playHostAudioBtn:focus, #rumbleFeedbackBtn:hover, #rumbleFeedbackBtn:focus,
 #mouseEmulationBtn:hover, #mouseEmulationBtn:focus, #flipABfaceButtonsBtn:hover,#flipABfaceButtonsBtn:focus, #flipXYfaceButtonsBtn:hover,
 #flipXYfaceButtonsBtn:focus, #selectAudio:hover, #selectAudio:focus, #audioSyncBtn:hover, #audioSyncBtn:focus, #selectCodec:hover, #selectCodec:focus,
-#hdrModeBtn:hover, #hdrModeBtn:focus, #fullRangeBtn:hover, #fullRangeBtn:focus, #systemInfoBtn:hover, #systemInfoBtn:focus, #removeAllHostsBtn:hover,
-#removeAllHostsBtn:focus, #navigationGuideBtn:hover, #navigationGuideBtn:focus, #checkUpdatesBtn:hover, #checkUpdatesBtn:focus, #restartAppBtn:hover,
-#restartAppBtn:focus {
+#hdrModeBtn:hover, #hdrModeBtn:focus, #fullRangeBtn:hover, #fullRangeBtn:focus, #disableWarningsBtn:hover, #disableWarningsBtn:focus,
+#systemInfoBtn:hover, #systemInfoBtn:focus, #removeAllHostsBtn:hover, #removeAllHostsBtn:focus, #navigationGuideBtn:hover, #navigationGuideBtn:focus,
+#checkUpdatesBtn:hover, #checkUpdatesBtn:focus, #restartAppBtn:hover, #restartAppBtn:focus {
     background-color: #404354;
     box-shadow: 0 0 2px 3px rgba(0, 163, 198, 1);
 }


### PR DESCRIPTION
### Description:
This pull request introduces a new **Connection warnings** setting within the **Video Settings** category, allowing users to toggle the on-screen overlay that displays connection warning messages during streaming.

### Changes proposed in this pull request:
- Added 'Connection warnings' option under the 'Video Settings' category.
- Added on-screen overlay for connection warnings, shown only during streaming sessions.
- Implemented support for disabling the connection warning overlay when selected.
- Connection status changes are monitored and warnings are shown based on network quality.
- Default behavior keeps the overlay enabled to notify users when connection quality is poor.