### PR TITLE
feat: Add overlay to display real-time stream performance information while streaming

### DIFF
--- a/wasm/gamepad.cpp
+++ b/wasm/gamepad.cpp
@@ -14,6 +14,9 @@
 // Bitmask for gamepad combo buttons to stop the streaming session
 const short STOP_STREAM_BUTTONS = BACK_FLAG | PLAY_FLAG | LB_FLAG | RB_FLAG;
 
+// Bitmask for gamepad combo buttons to toggle the performance stats overlay
+const short PERF_STATS_BUTTONS = BACK_FLAG | LB_FLAG | RB_FLAG | X_FLAG;
+
 // Flag for gamepad to track controller rumble state
 bool rumbleFeedbackSwitch = false;
 
@@ -161,6 +164,9 @@ void MoonlightInstance::PollGamepads() {
   // Create a mask for active gamepads
   const auto activeGamepadMask = GetActiveGamepadMask(numGamepads);
 
+  // Prevent repeated trigger while the button combo is held down
+  static bool comboTriggered = false;
+
   // Iterate through connected gamepads and process their input
   for (int gamepadID = 0; gamepadID < numGamepads; ++gamepadID) {
     emscripten_sample_gamepad_data();
@@ -201,6 +207,16 @@ void MoonlightInstance::PollGamepads() {
       // Terminate the connection
       stopStream();
       return;
+    } else if (buttonFlags == PERF_STATS_BUTTONS) {
+      if (!comboTriggered) {
+        // Toggle performance stats overlay
+        toggleStats();
+        // Mark combo as triggered until buttons are released
+        comboTriggered = true;
+      }
+    } else {
+      // Reset when buttons are released
+      comboTriggered = false;
     }
 
     // Check if the mouse emulation switch is checked

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -576,6 +576,10 @@
             <span class="navGuideRemoteText">RED</span> / <span class="navGuideKeyboardText">F1</span> / <span class="navGuideKeyboardText">CTRL + ALT + SHIFT + Q</span> / <span class="navGuideGamepadText">SELECT + START + LB + RB</span>
             — Stop the streaming session.
           </li>
+          <li class="navGuideDialogControls">
+            <span class="navGuideRemoteText">YELLOW</span> / <span class="navGuideKeyboardText">F3</span> / <span class="navGuideKeyboardText">CTRL + ALT + SHIFT + S</span> / <span class="navGuideGamepadText">SELECT + LB + RB + X</span>
+            — Toggle the performance statistics overlay.
+          </li>
         </ul>
       </div>
       <div class="mdl-dialog__actions">

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -387,6 +387,7 @@
       </div>
     </main>
     <div id="connection-warnings"></div>
+    <div id="performance-stats"></div>
   </div>
   <script defer src="static/js/jquery-2.2.0.min.js"></script>
   <script defer src="static/js/material.min.js"></script>

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -317,6 +317,16 @@
                 </label>
               </div>
             </div>
+            <div class="setting-option">
+              <label>Performance statistics</label>
+              <span class="mdl-list__item-text-body"></span>
+              <div id="performanceStatsMenu">
+                <label id="performanceStatsBtn" class="mdl-switch mdl-js-switch mdl-js-ripple-effect" for="performanceStatsSwitch">
+                  <input type="checkbox" id="performanceStatsSwitch" class="mdl-switch__input">
+                  <span class="mdl-switch__label">Display real-time stream performance information while streaming</span>
+                </label>
+              </div>
+            </div>
           </div>
           <div id="aboutSettings" class="settings-options">
             <div class="setting-option">

--- a/wasm/input.cpp
+++ b/wasm/input.cpp
@@ -92,6 +92,10 @@ EM_BOOL MoonlightInstance::HandleKeyDown(const EmscriptenKeyboardEvent &event) {
       // Terminate the connection
       stopStream();
       return EM_TRUE;
+    } else if (keyCode == 0x53) { // S key
+      // Toggle performance stats overlay
+      toggleStats();
+      return EM_TRUE;
     } else {
       // Wait until these keys come up to unlock the mouse
       m_WaitingForAllModifiersUp = true;

--- a/wasm/main.cpp
+++ b/wasm/main.cpp
@@ -485,6 +485,10 @@ MessageResult stopStream() {
   return g_Instance->StopStream();
 }
 
+void toggleStats() {
+  g_Instance->TogglePerformanceStats();
+}
+
 void stun(int callbackId) {
   g_Instance->STUN(callbackId);
 }
@@ -531,6 +535,7 @@ EMSCRIPTEN_BINDINGS(handle_message) {
   emscripten::value_object<MessageResult>("MessageResult").field("type", &MessageResult::type).field("ret", &MessageResult::ret);
   emscripten::function("startStream", &startStream);
   emscripten::function("stopStream", &stopStream);
+  emscripten::function("toggleStats", &toggleStats);
   emscripten::function("stun", &stun);
   emscripten::function("pair", &pair);
   emscripten::function("wakeOnLan", &wakeOnLan);

--- a/wasm/main.cpp
+++ b/wasm/main.cpp
@@ -210,7 +210,7 @@ static void HexStringToBytes(const char* str, char* output) {
 MessageResult MoonlightInstance::StartStream(std::string host, std::string width, std::string height, std::string fps, std::string bitrate,
   std::string rikey, std::string rikeyid, std::string appversion, std::string gfeversion, std::string rtspurl, int serverCodecModeSupport,
   bool framePacing, bool optimizeGames, bool playHostAudio, bool rumbleFeedback, bool mouseEmulation, bool flipABfaceButtons, bool flipXYfaceButtons,
-  std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange, bool disableWarnings) {
+  std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange, bool disableWarnings, bool performanceStats) {
   PostToJs("Setting the Host address to: " + host);
   PostToJs("Setting the Video resolution to: " + width + "x" + height);
   PostToJs("Setting the Video frame rate to: " + fps + " FPS");
@@ -234,6 +234,7 @@ MessageResult MoonlightInstance::StartStream(std::string host, std::string width
   PostToJs("Setting the Video HDR mode to: " + std::to_string(hdrMode));
   PostToJs("Setting the Full color range to: " + std::to_string(fullRange));
   PostToJs("Setting the Disable connection warnings to: " + std::to_string(disableWarnings));
+  PostToJs("Setting the Performance statistics to: " + std::to_string(performanceStats));
 
   // Populate the stream configuration
   LiInitializeStreamConfiguration(&m_StreamConfig);
@@ -331,6 +332,7 @@ MessageResult MoonlightInstance::StartStream(std::string host, std::string width
   m_HdrModeEnabled = hdrMode;
   m_FullRangeEnabled = fullRange;
   m_DisableWarningsEnabled = disableWarnings;
+  m_PerformanceStatsEnabled = performanceStats;
 
   // Initialize the rendering surface before starting the connection
   if (InitializeRenderingSurface(m_StreamConfig.width, m_StreamConfig.height)) {
@@ -471,11 +473,11 @@ int main(int argc, char** argv) {
 MessageResult startStream(std::string host, std::string width, std::string height, std::string fps, std::string bitrate,
   std::string rikey, std::string rikeyid, std::string appversion, std::string gfeversion, std::string rtspurl, int serverCodecModeSupport,
   bool framePacing, bool optimizeGames, bool playHostAudio, bool rumbleFeedback, bool mouseEmulation, bool flipABfaceButtons, bool flipXYfaceButtons,
-  std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange, bool disableWarnings) {
+  std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange, bool disableWarnings, bool performanceStats) {
   PostToJs("Starting the streaming session...");
   return g_Instance->StartStream(host, width, height, fps, bitrate, rikey, rikeyid, appversion, gfeversion, rtspurl, serverCodecModeSupport,
   framePacing, optimizeGames, playHostAudio, rumbleFeedback, mouseEmulation, flipABfaceButtons, flipXYfaceButtons, audioConfig,
-  audioSync, videoCodec, hdrMode, fullRange, disableWarnings);
+  audioSync, videoCodec, hdrMode, fullRange, disableWarnings, performanceStats);
 }
 
 MessageResult stopStream() {

--- a/wasm/moonlight_wasm.hpp
+++ b/wasm/moonlight_wasm.hpp
@@ -53,6 +53,31 @@ struct MessageResult {
   }
 };
 
+typedef struct _VIDEO_STATS {
+  uint32_t receivedFrames;
+  uint32_t decodedFrames;
+  uint32_t renderedFrames;
+  uint32_t totalFrames;
+  uint32_t networkDroppedFrames;
+  uint32_t pacerDroppedFrames;
+  uint16_t minHostProcessingLatency;
+  uint16_t maxHostProcessingLatency;
+  uint32_t totalHostProcessingLatency;
+  uint32_t framesWithHostProcessingLatency;
+  uint32_t totalReassemblyTime;
+  uint32_t totalDecodeTime;
+  uint32_t totalPacerTime;
+  uint32_t totalRenderTime;
+  uint32_t lastRtt;
+  uint32_t lastRttVariance;
+  float totalFps;
+  float receivedFps;
+  float decodedFps;
+  float renderedFps;
+  float receivedBitrate;
+  uint32_t measurementStartTimestamp;
+} VIDEO_STATS, *PVIDEO_STATS;
+
 enum class LoadResult {
   Success, CertErr, PrivateKeyErr
 };
@@ -126,6 +151,8 @@ class MoonlightInstance {
   static int StartupVidDecSetup(int videoFormat, int width, int height, int redrawRate, void* context, int drFlags);
   static void VidDecCleanup(void);
   static int VidDecSubmitDecodeUnit(PDECODE_UNIT decodeUnit);
+  static void AddVideoStats(VIDEO_STATS& src, VIDEO_STATS& dst);
+  static void FormatVideoStats(VIDEO_STATS& stats, char* output, int length);
 
   static int AudDecInit(int audioConfiguration, POPUS_MULTISTREAM_CONFIGURATION opusConfig, void* context, int arFlags);
   static void AudDecCleanup(void);

--- a/wasm/moonlight_wasm.hpp
+++ b/wasm/moonlight_wasm.hpp
@@ -66,7 +66,7 @@ class MoonlightInstance {
   MessageResult StartStream(std::string host, std::string width, std::string height, std::string fps, std::string bitrate,
     std::string rikey, std::string rikeyid, std::string appversion, std::string gfeversion, std::string rtspurl, int serverCodecModeSupport,
     bool framePacing, bool optimizeGames, bool playHostAudio, bool rumbleFeedback, bool mouseEmulation, bool flipABfaceButtons, bool flipXYfaceButtons,
-    std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange, bool disableWarnings);
+    std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange, bool disableWarnings, bool performanceStats);
   MessageResult StopStream();
 
   void STUN(int callbackId);
@@ -203,6 +203,7 @@ class MoonlightInstance {
   bool m_HdrModeEnabled;
   bool m_FullRangeEnabled;
   bool m_DisableWarningsEnabled;
+  bool m_PerformanceStatsEnabled;
 
   STREAM_CONFIGURATION m_StreamConfig;
   bool m_Running;
@@ -258,7 +259,7 @@ void openUrl(int callbackId, std::string url, emscripten::val ppk, bool binaryRe
 MessageResult startStream(std::string host, std::string width, std::string height, std::string fps, std::string bitrate,
   std::string rikey, std::string rikeyid, std::string appversion, std::string gfeversion, std::string rtspurl, int serverCodecModeSupport,
   bool framePacing, bool optimizeGames, bool playHostAudio, bool rumbleFeedback, bool mouseEmulation, bool flipABfaceButtons, bool flipXYfaceButtons,
-  std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange, bool disableWarnings);
+  std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange, bool disableWarnings, bool performanceStats);
 MessageResult stopStream();
 
 void stun(int callbackId);

--- a/wasm/moonlight_wasm.hpp
+++ b/wasm/moonlight_wasm.hpp
@@ -153,6 +153,7 @@ class MoonlightInstance {
   static int VidDecSubmitDecodeUnit(PDECODE_UNIT decodeUnit);
   static void AddVideoStats(VIDEO_STATS& src, VIDEO_STATS& dst);
   static void FormatVideoStats(VIDEO_STATS& stats, char* output, int length);
+  void TogglePerformanceStats();
 
   static int AudDecInit(int audioConfiguration, POPUS_MULTISTREAM_CONFIGURATION opusConfig, void* context, int arFlags);
   static void AudDecCleanup(void);
@@ -289,6 +290,7 @@ MessageResult startStream(std::string host, std::string width, std::string heigh
   std::string audioConfig, bool audioSync, std::string videoCodec, bool hdrMode, bool fullRange, bool disableWarnings, bool performanceStats);
 MessageResult stopStream();
 
+void toggleStats();
 void stun(int callbackId);
 void pair(int callbackId, std::string serverMajorVersion, std::string address, std::string randomNumber);
 void wakeOnLan(int callbackId, std::string macAddress);

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -278,6 +278,7 @@ function showHostsMode() {
   $('#restoreDefaultsBtn').hide();
   $('#quitRunningAppBtn').hide();
   $('#connection-warnings').css('display', 'none');
+  $('#performance-stats').css('display', 'none');
   $('#main-content').removeClass('fullscreen');
   $('#listener').removeClass('fullscreen');
 
@@ -1114,6 +1115,7 @@ function showSettingsMode() {
   $('#supportBtn').hide();
   $('#quitRunningAppBtn').hide();
   $('#connection-warnings').css('display', 'none');
+  $('#performance-stats').css('display', 'none');
   $('#main-content').removeClass('fullscreen');
   $('#listener').removeClass('fullscreen');
 
@@ -1764,6 +1766,7 @@ function showAppsMode() {
   $('#supportBtn').hide();
   $('#restoreDefaultsBtn').hide();
   $('#connection-warnings').css('display', 'none');
+  $('#performance-stats').css('display', 'none');
   $('#main-content').removeClass('fullscreen');
   $('#listener').removeClass('fullscreen');
   $('#loadingSpinner').css('display', 'none');
@@ -2014,9 +2017,13 @@ function fullscreenWasmModule() {
 function handleOnScreenOverlays() {
   // Find the existing toggle switch elements
   const disableWarningsSwitch = document.getElementById('disableWarningsSwitch');
+  const performanceStatsSwitch = document.getElementById('performanceStatsSwitch');
 
   // Check if the disable warnings switch is checked, then hide or show the connection warning messages
   disableWarningsSwitch.checked ? $('#connection-warnings').css('display', 'none') : $('#connection-warnings').css('display', 'inline-block');
+
+  // Check if the performance stats switch is checked, then show or hide the performance statistics information
+  performanceStatsSwitch.checked ? $('#performance-stats').css('display', 'inline-block') : $('#performance-stats').css('display', 'none');
 }
 
 // Start the given appID. If another app is running, offer to quit it. Otherwise, if the given app is already running, just resume it.
@@ -2126,7 +2133,7 @@ function startGame(host, appID) {
       '\n Performance statistics: ' + performanceStats);
 
       // Hide on-screen overlays until the streaming session begins
-      $('#connection-warnings').css('background', 'transparent').text('');
+      $('#connection-warnings, #performance-stats').css('background', 'transparent').text('');
 
       // Shows a loading message to launch the application and start stream mode
       $('#loadingSpinnerMessage').text('Starting ' + appToStart.title + '...');

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -52,6 +52,7 @@ function attachListeners() {
   $('#hdrModeSwitch').on('click', saveHdrMode);
   $('#fullRangeSwitch').on('click', saveFullRange);
   $('#disableWarningsSwitch').on('click', saveDisableWarnings);
+  $('#performanceStatsSwitch').on('click', savePerformanceStats);
   $('#navigationGuideBtn').on('click', navigationGuideDialog);
   $('#checkUpdatesBtn').on('click', checkForAppUpdates);
   $('#restartAppBtn').on('click', restartAppDialog);
@@ -2102,6 +2103,7 @@ function startGame(host, appID) {
       const hdrMode = $('#hdrModeSwitch').parent().hasClass('is-checked') ? 1 : 0;
       const fullRange = $('#fullRangeSwitch').parent().hasClass('is-checked') ? 1 : 0;
       const disableWarnings = $('#disableWarningsSwitch').parent().hasClass('is-checked') ? 1 : 0;
+      const performanceStats = $('#performanceStatsSwitch').parent().hasClass('is-checked') ? 1 : 0;
 
       console.log('%c[index.js, startGame]', 'color: green;', 'startRequest:' + 
       '\n Host address: ' + host.address + 
@@ -2120,7 +2122,8 @@ function startGame(host, appID) {
       '\n Video codec: ' + videoCodec + 
       '\n Video HDR mode: ' + hdrMode + 
       '\n Full color range: ' + fullRange + 
-      '\n Disable connection warnings: ' + disableWarnings);
+      '\n Disable connection warnings: ' + disableWarnings + 
+      '\n Performance statistics: ' + performanceStats);
 
       // Hide on-screen overlays until the streaming session begins
       $('#connection-warnings').css('background', 'transparent').text('');
@@ -2162,7 +2165,7 @@ function startGame(host, appID) {
             host.address, streamWidth, streamHeight, frameRate, bitrate.toString(), rikey, rikeyid.toString(),
             host.appVersion, host.gfeVersion, $root.find('sessionUrl0').text().trim(), host.serverCodecModeSupport,
             framePacing, optimizeGames, playHostAudio, rumbleFeedback, mouseEmulation, flipABfaceButtons, flipXYfaceButtons,
-            audioConfig, audioSync, videoCodec, hdrMode, fullRange, disableWarnings
+            audioConfig, audioSync, videoCodec, hdrMode, fullRange, disableWarnings, performanceStats
           ]);
         }, function(failedResumeApp) {
           console.error('%c[index.js, startGame]', 'color: green;', 'Error: Failed to resume app with id: ' + appID + '\n Returned error was: ' + failedResumeApp + '!');
@@ -2215,7 +2218,7 @@ function startGame(host, appID) {
           host.address, streamWidth, streamHeight, frameRate, bitrate.toString(), rikey, rikeyid.toString(),
           host.appVersion, host.gfeVersion, $root.find('sessionUrl0').text().trim(), host.serverCodecModeSupport,
           framePacing, optimizeGames, playHostAudio, rumbleFeedback, mouseEmulation, flipABfaceButtons, flipXYfaceButtons,
-          audioConfig, audioSync, videoCodec, hdrMode, fullRange, disableWarnings
+          audioConfig, audioSync, videoCodec, hdrMode, fullRange, disableWarnings, performanceStats
         ]);
       }, function(failedLaunchApp) {
         console.error('%c[index.js, startGame]', 'color: green;', 'Error: Failed to launch app with id: ' + appID + '\n Returned error was: ' + failedLaunchApp + '!');
@@ -2757,6 +2760,14 @@ function saveDisableWarnings() {
   }, 100);
 }
 
+function savePerformanceStats() {
+  setTimeout(() => {
+    const chosenPerformanceStats = $('#performanceStatsSwitch').parent().hasClass('is-checked');
+    console.log('%c[index.js, savePerformanceStats]', 'color: green;', 'Saving performance stats state: ' + chosenPerformanceStats);
+    storeData('performanceStats', chosenPerformanceStats, null);
+  }, 100);
+}
+
 // Reset all settings to their default state and save the value data
 function restoreDefaultsSettingsValues() {
   const defaultResolution = '1280:720';
@@ -2831,6 +2842,10 @@ function restoreDefaultsSettingsValues() {
   const defaultDisableWarnings = false;
   document.querySelector('#disableWarningsBtn').MaterialSwitch.off();
   storeData('disableWarnings', defaultDisableWarnings, null);
+
+  const defaultPerformanceStats = false;
+  document.querySelector('#performanceStatsBtn').MaterialSwitch.off();
+  storeData('performanceStats', defaultPerformanceStats, null);
 }
 
 function initSamsungKeys() {
@@ -3122,6 +3137,17 @@ function loadUserDataCb() {
       document.querySelector('#disableWarningsBtn').MaterialSwitch.off();
     } else {
       document.querySelector('#disableWarningsBtn').MaterialSwitch.on();
+    }
+  });
+
+  console.log('%c[index.js, loadUserDataCb]', 'color: green;', 'Load stored performanceStats preferences.');
+  getData('performanceStats', function(previousValue) {
+    if (previousValue.performanceStats == null) {
+      document.querySelector('#performanceStatsBtn').MaterialSwitch.off(); // Set the default state
+    } else if (previousValue.performanceStats == false) {
+      document.querySelector('#performanceStatsBtn').MaterialSwitch.off();
+    } else {
+      document.querySelector('#performanceStatsBtn').MaterialSwitch.on();
     }
   });
 }

--- a/wasm/platform/messages.js
+++ b/wasm/platform/messages.js
@@ -73,7 +73,7 @@ function handleMessage(msg) {
   // If it's a recognized event, notify the appropriate function
   if (msg.indexOf('streamTerminated: ') === 0) {
     // Remove the on-screen overlays
-    $('#connection-warnings').css('display', 'none');
+    $('#connection-warnings, #performance-stats').css('display', 'none');
     // Remove the video stream now
     $('#listener').removeClass('fullscreen');
     $('#loadingSpinner').css('display', 'none');

--- a/wasm/platform/messages.js
+++ b/wasm/platform/messages.js
@@ -11,6 +11,8 @@ const SyncFunctions = {
   'startRequest': (...args) => Module.startStream(...args),
   // no parameters
   'stopRequest': (...args) => Module.stopStream(...args),
+  // no parameters
+  'toggleStats': (...args) => Module.toggleStats(...args),
 };
 
 const AsyncFunctions = {
@@ -139,10 +141,22 @@ function handleMessage(msg) {
     $('#connection-warnings').css('background', 'rgba(0, 0, 0, 0.5)');
     $('#connection-warnings').text(msg.replace('WarningMsg: ', ''));
   } else if (msg.indexOf('NoStatMsg: ') === 0) {
+    // Toggle the performance stats switch and save the state
+    if ($('#performanceStatsSwitch').prop('checked')) {
+      $('#performanceStatsBtn')[0].MaterialSwitch.off();
+      savePerformanceStats();
+      $('#performance-stats').css('display', 'none');
+    }
     // Hide the performance statistics overlay
     $('#performance-stats').css('background', 'transparent');
     $('#performance-stats').text('');
   } else if (msg.indexOf('StatMsg: ') === 0) {
+    // Toggle the performance stats switch and save the state
+    if (!$('#performanceStatsSwitch').prop('checked')) {
+      $('#performanceStatsBtn')[0].MaterialSwitch.on();
+      savePerformanceStats();
+      $('#performance-stats').css('display', 'inline-block');
+    }
     // Show the performance statistics overlay
     $('#performance-stats').css('background', 'rgba(0, 0, 0, 0.5)');
     $('#performance-stats').text(msg.replace('StatMsg: ', ''));

--- a/wasm/platform/messages.js
+++ b/wasm/platform/messages.js
@@ -138,6 +138,14 @@ function handleMessage(msg) {
     // Show the connection warnings overlay
     $('#connection-warnings').css('background', 'rgba(0, 0, 0, 0.5)');
     $('#connection-warnings').text(msg.replace('WarningMsg: ', ''));
+  } else if (msg.indexOf('NoStatMsg: ') === 0) {
+    // Hide the performance statistics overlay
+    $('#performance-stats').css('background', 'transparent');
+    $('#performance-stats').text('');
+  } else if (msg.indexOf('StatMsg: ') === 0) {
+    // Show the performance statistics overlay
+    $('#performance-stats').css('background', 'rgba(0, 0, 0, 0.5)');
+    $('#performance-stats').text(msg.replace('StatMsg: ', ''));
   } else if (msg.indexOf('controllerRumble: ') === 0) {
     const eventData = msg.split(' ')[1].split(',');
     const gamepadIdx = parseInt(eventData[0]);

--- a/wasm/platform/messages.js
+++ b/wasm/platform/messages.js
@@ -7,7 +7,7 @@ const SyncFunctions = {
   'httpInit': (...args) => Module.httpInit(...args),
   /* host, width, height, fps, bitrate, rikey, rikeyid, appversion, gfeversion, rtspurl, serverCodecModeSupport,
   framePacing, optimizeGames, playHostAudio, rumbleFeedback, mouseEmulation, flipABfaceButtons, flipXYfaceButtons,
-  audioConfig, audioSync, videoCodec, hdrMode, fullRange, disableWarnings */
+  audioConfig, audioSync, videoCodec, hdrMode, fullRange, disableWarnings, performanceStats */
   'startRequest': (...args) => Module.startStream(...args),
   // no parameters
   'stopRequest': (...args) => Module.stopStream(...args),

--- a/wasm/platform/navigation.js
+++ b/wasm/platform/navigation.js
@@ -1036,7 +1036,8 @@ const Views = {
       'selectCodec',
       'hdrModeBtn',
       'fullRangeBtn',
-      'disableWarningsBtn'
+      'disableWarningsBtn',
+      'performanceStatsBtn'
     ]),
     up: function() {
       this.view.prevOption();

--- a/wasm/platform/remote_controller.js
+++ b/wasm/platform/remote_controller.js
@@ -53,6 +53,12 @@ function remoteControllerHandler(e) {
         Module.stopStream();
       }
       break;
+    case tvKey.KEY_YELLOW:
+      // Toggle performance stats overlay
+      if (isInGame === true) {
+        Module.toggleStats();
+      }
+      break;
     default:
       break;
   }

--- a/wasm/static/css/style.css
+++ b/wasm/static/css/style.css
@@ -674,6 +674,20 @@ body {
     line-height: 1.2;
     white-space: pre-wrap;
 }
+#performance-stats {
+    color: #fff;
+    background: transparent;
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    z-index: 3;
+    padding: 10px;
+    border-radius: 8px;
+    font-size: 1.8rem;
+    font-weight: 500;
+    line-height: 1.2;
+    white-space: pre-wrap;
+}
 /* =============================
    Settings Section
 ============================= */

--- a/wasm/static/css/style.css
+++ b/wasm/static/css/style.css
@@ -841,7 +841,8 @@ body {
 #ipAddressFieldModeBtn, #sortAppsListBtn, #optimizeGamesBtn, #playHostAudioBtn,
 #removeAllHostsBtn, #rumbleFeedbackBtn, #mouseEmulationBtn, #flipABfaceButtonsBtn,
 #flipXYfaceButtonsBtn, #selectAudio, #audioSyncBtn, #selectCodec, #hdrModeBtn,
-#fullRangeBtn, #disableWarningsBtn, #navigationGuideBtn, #checkUpdatesBtn, #restartAppBtn {
+#fullRangeBtn, #disableWarningsBtn, #performanceStatsBtn, #navigationGuideBtn,
+#checkUpdatesBtn, #restartAppBtn {
     color: #ececec;
     background-color: #404354;
     width: 100%;
@@ -955,8 +956,8 @@ body {
 #mouseEmulationBtn:hover, #mouseEmulationBtn:focus, #flipABfaceButtonsBtn:hover,#flipABfaceButtonsBtn:focus, #flipXYfaceButtonsBtn:hover,
 #flipXYfaceButtonsBtn:focus, #selectAudio:hover, #selectAudio:focus, #audioSyncBtn:hover, #audioSyncBtn:focus, #selectCodec:hover, #selectCodec:focus,
 #hdrModeBtn:hover, #hdrModeBtn:focus, #fullRangeBtn:hover, #fullRangeBtn:focus, #disableWarningsBtn:hover, #disableWarningsBtn:focus,
-#systemInfoBtn:hover, #systemInfoBtn:focus, #removeAllHostsBtn:hover, #removeAllHostsBtn:focus, #navigationGuideBtn:hover, #navigationGuideBtn:focus,
-#checkUpdatesBtn:hover, #checkUpdatesBtn:focus, #restartAppBtn:hover, #restartAppBtn:focus {
+#performanceStatsBtn:hover, #performanceStatsBtn:focus, #systemInfoBtn:hover, #systemInfoBtn:focus, #removeAllHostsBtn:hover, #removeAllHostsBtn:focus,
+#navigationGuideBtn:hover, #navigationGuideBtn:focus, #checkUpdatesBtn:hover, #checkUpdatesBtn:focus, #restartAppBtn:hover, #restartAppBtn:focus {
     background-color: #404354;
     box-shadow: 0 0 2px 3px rgba(0, 163, 198, 1);
 }

--- a/wasm/wasmplayer.cpp
+++ b/wasm/wasmplayer.cpp
@@ -679,6 +679,18 @@ void MoonlightInstance::FormatVideoStats(VIDEO_STATS& stats, char* output, int l
   }
 }
 
+void MoonlightInstance::TogglePerformanceStats() {
+  // Toggle the performance stats overlay flag
+  m_PerformanceStatsEnabled = !m_PerformanceStatsEnabled;
+
+  // Notify the JS code that performance stats overlay is enabled or disabled
+  if (m_PerformanceStatsEnabled) {
+    PostToJs(std::string("StatMsg: ") + s_StatString.data());
+  } else {
+    PostToJs(std::string("NoStatMsg: "));
+  }
+}
+
 void MoonlightInstance::WaitFor(std::condition_variable* variable, std::function<bool()> condition) {
   std::unique_lock<std::mutex> lock(m_Mutex);
   variable->wait(lock, condition);


### PR DESCRIPTION
### Description:
This pull request introduces a new **Performance statistics** setting within the **Video Settings** category, allowing users to toggle the on-screen overlay that displays real-time stream performance information while streaming.

### Changes proposed in this pull request:
- Added 'Performance statistics' option under the 'Video Settings' category.
- Added on-screen overlay for performance statistics, shown only during streaming sessions.
- Implemented support for enabling the performance statistics overlay when selected.
- Added aggregated metrics, including calculations and measurements for performance stats in a formatted output.
- Performance stats updates are handled and metrics are displayed based on stream performance.
- Shortcut functionality implemented to toggle performance stats using the remote control, keyboard, or gamepad.
- Default behavior keeps the overlay disabled to avoid obstructing the view during the stream session.