### PR TITLE
fix: Adjusted high-resolution scroll event scaling factor for smoother wheel input

### DIFF
--- a/wasm/input.cpp
+++ b/wasm/input.cpp
@@ -176,7 +176,7 @@ void MoonlightInstance::ReportMouseMovement() {
   if (m_AccumulatedTicks != 0) {
     // We can have fractional ticks here, so multiply by WHEEL_DELTA
     // to get actual scroll distance and use the high-res variant.
-    LiSendHighResScrollEvent(m_AccumulatedTicks * 120);
+    LiSendHighResScrollEvent(m_AccumulatedTicks);
     m_AccumulatedTicks = 0;
   }
 }

--- a/wasm/input.cpp
+++ b/wasm/input.cpp
@@ -176,7 +176,7 @@ void MoonlightInstance::ReportMouseMovement() {
   if (m_AccumulatedTicks != 0) {
     // We can have fractional ticks here, so multiply by WHEEL_DELTA
     // to get actual scroll distance and use the high-res variant.
-    LiSendHighResScrollEvent(m_AccumulatedTicks);
+    LiSendHighResScrollEvent(m_AccumulatedTicks * 5);
     m_AccumulatedTicks = 0;
   }
 }


### PR DESCRIPTION
### Description:
The mouse wheel input was scaled with a fixed value (possibly for ChromeOS, as it mentions a high-res variant). This caused mouse wheel actions to be way too strong.

I can only test the impact of this change on Tizen 8, where it solves the issue of a basically unusable mouse wheel.

### Changes proposed in this pull request:
- Remove fixed scale value of 120
