### PR TITLE
feat: Add a new setting to unlock all possible frame rate options up to 144 FPS

### DIFF
--- a/wasm/index.html
+++ b/wasm/index.html
@@ -121,8 +121,6 @@
               <ul class="videoFramerateMenu mdl-menu mdl-menu--bottom-left mdl-js-menu mdl-js-ripple-effect" for="selectFramerate">
                 <li class="mdl-menu__item" data-value="30">30 FPS</li>
                 <li class="mdl-menu__item" data-value="60">60 FPS</li>
-                <li class="mdl-menu__item" data-value="90">90 FPS</li>
-                <li class="mdl-menu__item" data-value="120">120 FPS</li>
               </ul>
             </div>
             <div class="setting-option">

--- a/wasm/index.html
+++ b/wasm/index.html
@@ -164,6 +164,18 @@
               </div>
             </div>
             <div class="setting-option">
+              <label>Unlock all frame rates</label>
+              <span class="mdl-list__item-text-body">
+                - Higher FPS can reduce latency on high-end devices, but may cause lag or instability on unsupported devices.
+              </span>
+              <div id="unlockAllFpsMenu">
+                <label id="unlockAllFpsBtn" class="mdl-switch mdl-js-switch mdl-js-ripple-effect" for="unlockAllFpsSwitch">
+                  <input type="checkbox" id="unlockAllFpsSwitch" class="mdl-switch__input" onchange="handleUnlockAllFps()">
+                  <span class="mdl-switch__label">Unlock all possible frame rate options for this device</span>
+                </label>
+              </div>
+            </div>
+            <div class="setting-option">
               <label>Connection warnings</label>
               <span class="mdl-list__item-text-body"></span>
               <div id="connectionWarningsMenu">

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -2519,6 +2519,8 @@ function setBitratePresetValue() {
       $('#bitrateSlider')[0].MaterialSlider.change('5');
     } else if (frameRate === '120') { // 120 FPS
       $('#bitrateSlider')[0].MaterialSlider.change('6');
+    } else if (frameRate === '144') { // 144 FPS
+      $('#bitrateSlider')[0].MaterialSlider.change('8');
     }
   } else if (res === '1280:720') { // 720p
     if (frameRate === '30') { // 30 FPS
@@ -2529,6 +2531,8 @@ function setBitratePresetValue() {
       $('#bitrateSlider')[0].MaterialSlider.change('12');
     } else if (frameRate === '120') { // 120 FPS
       $('#bitrateSlider')[0].MaterialSlider.change('15');
+    } else if (frameRate === '144') { // 144 FPS
+      $('#bitrateSlider')[0].MaterialSlider.change('18');
     }
   } else if (res === '1920:1080') { // 1080p
     if (frameRate === '30') { // 30 FPS
@@ -2539,6 +2543,8 @@ function setBitratePresetValue() {
       $('#bitrateSlider')[0].MaterialSlider.change('25');
     } else if (frameRate === '120') { // 120 FPS
       $('#bitrateSlider')[0].MaterialSlider.change('30');
+    } else if (frameRate === '144') { // 144 FPS
+      $('#bitrateSlider')[0].MaterialSlider.change('35');
     }
   } else if (res === '2560:1440') { // 1440p
     if (frameRate === '30') { // 30 FPS
@@ -2549,6 +2555,8 @@ function setBitratePresetValue() {
       $('#bitrateSlider')[0].MaterialSlider.change('50');
     } else if (frameRate === '120') { // 120 FPS
       $('#bitrateSlider')[0].MaterialSlider.change('60');
+    } else if (frameRate === '144') { // 144 FPS
+      $('#bitrateSlider')[0].MaterialSlider.change('70');
     }
   } else if (res === '3840:2160') { // 2160p
     if (frameRate === '30') { // 30 FPS
@@ -2559,6 +2567,8 @@ function setBitratePresetValue() {
       $('#bitrateSlider')[0].MaterialSlider.change('100');
     } else if (frameRate === '120') { // 120 FPS
       $('#bitrateSlider')[0].MaterialSlider.change('120');
+    } else if (frameRate === '144') { // 144 FPS
+      $('#bitrateSlider')[0].MaterialSlider.change('140');
     }
   } else {
     // Unrecognized option! In case someone screws with the JS to add custom resolutions.
@@ -2599,23 +2609,24 @@ function handleUnlockAllFps() {
 
   // Check if the Unlock all FPS switch is checked
   if ($('#unlockAllFpsSwitch').prop('checked')) {
-    console.log('%c[index.js, handleUnlockAllFps]', 'color: green;', 'Adding higher framerate options: 90, 120 FPS');
+    console.log('%c[index.js, handleUnlockAllFps]', 'color: green;', 'Adding higher framerate options: 90, 120, 144 FPS');
     // Check if any of the higher FPS options are absent to avoid duplicates
-    if (!$('.videoFramerateMenu').find('li[data-value="90"], li[data-value="120"]').length) {
-      // Insert all higher FPS options in correct order (90, 120)
+    if (!$('.videoFramerateMenu').find('li[data-value="90"], li[data-value="120"], li[data-value="144"]').length) {
+      // Insert all higher FPS options in correct order (90, 120, 144)
       addFramerate.after(`
         <li class="mdl-menu__item" data-value="90">90 FPS</li>
         <li class="mdl-menu__item" data-value="120">120 FPS</li>
+        <li class="mdl-menu__item" data-value="144">144 FPS</li>
       `);
       // Attach click listeners only to the newly added FPS options
-      $('.videoFramerateMenu li[data-value="90"], li[data-value="120"]').on('click', saveFramerate);
+      $('.videoFramerateMenu li[data-value="90"], li[data-value="120"], li[data-value="144"]').on('click', saveFramerate);
     }
   } else {
-    console.log('%c[index.js, handleUnlockAllFps]', 'color: green;', 'Removing higher framerate options: 90, 120 FPS');
+    console.log('%c[index.js, handleUnlockAllFps]', 'color: green;', 'Removing higher framerate options: 90, 120, 144 FPS');
     // If unchecked, remove the higher FPS options from the selection menu
-    $('.videoFramerateMenu li[data-value="90"], li[data-value="120"]').remove();
+    $('.videoFramerateMenu li[data-value="90"], li[data-value="120"], li[data-value="144"]').remove();
     // After removal, if a higher FPS option remains selected, then reset it to the default option
-    if (['90', '120'].includes(String(currentFps))) {
+    if (['90', '120', '144'].includes(String(currentFps))) {
       $('#selectFramerate').text('60 FPS').data('value', '60');
       console.log('%c[index.js, handleUnlockAllFps]', 'color: green;', 'Resetting framerate value to 60 FPS');
       storeData('frameRate', '60', null);

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -38,6 +38,7 @@ function attachListeners() {
   $('#bitrateSlider').on('input', saveBitrate);
   $('#framePacingSwitch').on('click', saveFramePacing);
   $('#ipAddressFieldModeSwitch').on('click', saveIpAddressFieldMode);
+  $('#unlockAllFpsSwitch').on('click', saveUnlockAllFps);
   $('#disableWarningsSwitch').on('click', saveDisableWarnings);
   $('#performanceStatsSwitch').on('click', savePerformanceStats);
   $('#sortAppsListSwitch').on('click', saveSortAppsList);
@@ -2584,6 +2585,46 @@ function saveIpAddressFieldMode() {
   }, 100);
 }
 
+function saveUnlockAllFps() {
+  setTimeout(() => {
+    const chosenUnlockAllFps = $('#unlockAllFpsSwitch').parent().hasClass('is-checked');
+    console.log('%c[index.js, saveUnlockAllFps]', 'color: green;', 'Saving unlock all FPS state: ' + chosenUnlockAllFps);
+    storeData('unlockAllFps', chosenUnlockAllFps, null);
+  }, 100);
+}
+
+function handleUnlockAllFps() {
+  var currentFps = $('#selectFramerate').data('value');
+  const addFramerate = $('.videoFramerateMenu').find('li[data-value="60"]');
+
+  // Check if the Unlock all FPS switch is checked
+  if ($('#unlockAllFpsSwitch').prop('checked')) {
+    console.log('%c[index.js, handleUnlockAllFps]', 'color: green;', 'Adding higher framerate options: 90, 120 FPS');
+    // Check if any of the higher FPS options are absent to avoid duplicates
+    if (!$('.videoFramerateMenu').find('li[data-value="90"], li[data-value="120"]').length) {
+      // Insert all higher FPS options in correct order (90, 120)
+      addFramerate.after(`
+        <li class="mdl-menu__item" data-value="90">90 FPS</li>
+        <li class="mdl-menu__item" data-value="120">120 FPS</li>
+      `);
+      // Attach click listeners only to the newly added FPS options
+      $('.videoFramerateMenu li[data-value="90"], li[data-value="120"]').on('click', saveFramerate);
+    }
+  } else {
+    console.log('%c[index.js, handleUnlockAllFps]', 'color: green;', 'Removing higher framerate options: 90, 120 FPS');
+    // If unchecked, remove the higher FPS options from the selection menu
+    $('.videoFramerateMenu li[data-value="90"], li[data-value="120"]').remove();
+    // After removal, if a higher FPS option remains selected, then reset it to the default option
+    if (['90', '120'].includes(String(currentFps))) {
+      $('#selectFramerate').text('60 FPS').data('value', '60');
+      console.log('%c[index.js, handleUnlockAllFps]', 'color: green;', 'Resetting framerate value to 60 FPS');
+      storeData('frameRate', '60', null);
+      // Update the bitrate value based on the selected frame rate
+      setBitratePresetValue();
+    }
+  }
+}
+
 function saveDisableWarnings() {
   setTimeout(() => {
     const chosenDisableWarnings = $('#disableWarningsSwitch').parent().hasClass('is-checked');
@@ -2803,6 +2844,10 @@ function restoreDefaultsSettingsValues() {
   document.querySelector('#ipAddressFieldModeBtn').MaterialSwitch.off();
   storeData('ipAddressFieldMode', defaultIpAddressFieldMode, null);
 
+  const defaultUnlockAllFps = false;
+  document.querySelector('#unlockAllFpsBtn').MaterialSwitch.off();
+  storeData('unlockAllFps', defaultUnlockAllFps, null);
+
   const defaultDisableWarnings = false;
   document.querySelector('#disableWarningsBtn').MaterialSwitch.off();
   storeData('disableWarnings', defaultDisableWarnings, null);
@@ -2962,6 +3007,19 @@ function loadUserDataCb() {
         }
       });
     }
+  });
+
+  console.log('%c[index.js, loadUserDataCb]', 'color: green;', 'Load stored unlockAllFps preferences.');
+  getData('unlockAllFps', function(previousValue) {
+    if (previousValue.unlockAllFps == null) {
+      document.querySelector('#unlockAllFpsBtn').MaterialSwitch.off(); // Set the default state
+    } else if (previousValue.unlockAllFps == false) {
+      document.querySelector('#unlockAllFpsBtn').MaterialSwitch.off();
+    } else {
+      document.querySelector('#unlockAllFpsBtn').MaterialSwitch.on();
+    }
+    // Handle the Unlocked FPS visibility based on switch state
+    handleUnlockAllFps();
   });
 
   console.log('%c[index.js, loadUserDataCb]', 'color: green;', 'Load stored frameRate preferences.');

--- a/wasm/platform/navigation.js
+++ b/wasm/platform/navigation.js
@@ -853,6 +853,7 @@ const Views = {
   InterfaceSettings: {
     view: new ListView(() => [
       'ipAddressFieldModeBtn',
+      'unlockAllFpsBtn',
       'disableWarningsBtn',
       'performanceStatsBtn'
     ]),

--- a/wasm/static/css/style.css
+++ b/wasm/static/css/style.css
@@ -852,9 +852,9 @@ body {
     text-indent: 36px;
 }
 #selectResolution, #selectFramerate, #selectBitrate, #framePacingBtn, #ipAddressFieldModeBtn,
-#disableWarningsBtn, #performanceStatsBtn, #sortAppsListBtn, #optimizeGamesBtn, #removeAllHostsBtn,
-#rumbleFeedbackBtn, #mouseEmulationBtn, #flipABfaceButtonsBtn, #flipXYfaceButtonsBtn, #selectAudio,
-#audioSyncBtn, #playHostAudioBtn, #selectCodec, #hdrModeBtn, #fullRangeBtn, #navigationGuideBtn,
+#unlockAllFpsBtn, #disableWarningsBtn, #performanceStatsBtn, #sortAppsListBtn, #optimizeGamesBtn,
+#removeAllHostsBtn, #rumbleFeedbackBtn, #mouseEmulationBtn, #flipABfaceButtonsBtn, #flipXYfaceButtonsBtn,
+#selectAudio, #audioSyncBtn, #playHostAudioBtn, #selectCodec, #hdrModeBtn, #fullRangeBtn, #navigationGuideBtn,
 #checkUpdatesBtn, #restartAppBtn {
     color: #ececec;
     background-color: #404354;
@@ -964,13 +964,14 @@ body {
 #cancelExitApp:focus, #settingsBtn:hover, #settingsBtn:focus, #supportBtn:hover, #supportBtn:focus, #goBackBtn:hover, #goBackBtn:focus,
 #restoreDefaultsBtn:hover, #restoreDefaultsBtn:focus, #quitRunningAppBtn:hover, #quitRunningAppBtn:focus, #selectResolution:hover,
 #selectResolution:focus, #selectFramerate:hover, #selectFramerate:focus, #selectBitrate:hover, #selectBitrate:focus, #framePacingBtn:hover,
-#framePacingBtn:focus, #ipAddressFieldModeBtn:hover, #ipAddressFieldModeBtn:focus, #disableWarningsBtn:hover, #disableWarningsBtn:focus,
-#performanceStatsBtn:hover, #performanceStatsBtn:focus, #sortAppsListBtn:hover, #sortAppsListBtn:focus, #optimizeGamesBtn:hover, #optimizeGamesBtn:focus,
-#removeAllHostsBtn:hover, #removeAllHostsBtn:focus, #rumbleFeedbackBtn:hover, #rumbleFeedbackBtn:focus, #mouseEmulationBtn:hover, #mouseEmulationBtn:focus,
-#flipABfaceButtonsBtn:hover, #flipABfaceButtonsBtn:focus, #flipXYfaceButtonsBtn:hover, #flipXYfaceButtonsBtn:focus, #selectAudio:hover, #selectAudio:focus,
-#audioSyncBtn:hover, #audioSyncBtn:focus, #playHostAudioBtn:hover, #playHostAudioBtn:focus, #selectCodec:hover, #selectCodec:focus, #hdrModeBtn:hover,
-#hdrModeBtn:focus, #fullRangeBtn:hover, #fullRangeBtn:focus, #systemInfoBtn:hover, #systemInfoBtn:focus, #navigationGuideBtn:hover, #navigationGuideBtn:focus,
-#checkUpdatesBtn:hover, #checkUpdatesBtn:focus, #restartAppBtn:hover, #restartAppBtn:focus {
+#framePacingBtn:focus, #ipAddressFieldModeBtn:hover, #ipAddressFieldModeBtn:focus, #unlockAllFpsBtn:hover, #unlockAllFpsBtn:focus,
+#disableWarningsBtn:hover, #disableWarningsBtn:focus, #performanceStatsBtn:hover, #performanceStatsBtn:focus, #sortAppsListBtn:hover,
+#sortAppsListBtn:focus, #optimizeGamesBtn:hover, #optimizeGamesBtn:focus, #removeAllHostsBtn:hover, #removeAllHostsBtn:focus, #rumbleFeedbackBtn:hover,
+#rumbleFeedbackBtn:focus, #mouseEmulationBtn:hover, #mouseEmulationBtn:focus, #flipABfaceButtonsBtn:hover, #flipABfaceButtonsBtn:focus,
+#flipXYfaceButtonsBtn:hover, #flipXYfaceButtonsBtn:focus, #selectAudio:hover, #selectAudio:focus, #audioSyncBtn:hover, #audioSyncBtn:focus,
+#playHostAudioBtn:hover, #playHostAudioBtn:focus, #selectCodec:hover, #selectCodec:focus, #hdrModeBtn:hover, #hdrModeBtn:focus, #fullRangeBtn:hover,
+#fullRangeBtn:focus, #systemInfoBtn:hover, #systemInfoBtn:focus, #navigationGuideBtn:hover, #navigationGuideBtn:focus, #checkUpdatesBtn:hover,
+#checkUpdatesBtn:focus, #restartAppBtn:hover, #restartAppBtn:focus {
     background-color: #404354;
     box-shadow: 0 0 2px 3px rgba(0, 163, 198, 1);
 }


### PR DESCRIPTION
### Description:
This pull request introduces a new **"Unlock all frame rates"** setting within the **UI Settings** category. When enabled, this option allows users to select higher frame rate values such as **90 FPS**, **120 FPS**, and **144 FPS**, in addition to the standard **30 FPS** and **60 FPS** options.

This approach provides greater flexibility for users with higher refresh rate displays, while keeping the default settings simple and compatible for all devices. It also avoids confusion for users with lower refresh rate displays, since seeing higher FPS options might make them think their device can support them, which could lead to black screens, lag, or other instability issues.

### Changes proposed in this pull request:
- Added a new **"Unlock all frame rates"** setting under the **UI Settings** category.
- Added a new **144 FPS** option as part of the **"Unlock all frame rates"** setting.
- Implemented logic to dynamically include higher FPS options (90, 120, 144) when enabled.
- Updated the **"Video frame rate"** field to reflect the new configuration option.
- Default behavior offers **30 FPS** and **60 FPS** options for broad compatibility across all devices.
