### PR TITLE
feat: Optimize Dockerfile to prevent C++ recompilation on frontend changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN ./emsdk activate latest-fastcomp
 RUN echo 'JAVA = "/usr/bin/java"' >> /home/moonlight/.emscripten
 
 # Copy ONLY the files required for C++ compilation
+WORKDIR /home/moonlight
 COPY --chown=moonlight CMakeLists.txt ./moonlight-tizen/
 COPY --chown=moonlight h264bitstream ./moonlight-tizen/h264bitstream/
 COPY --chown=moonlight libgamestream ./moonlight-tizen/libgamestream/

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,15 +55,31 @@ WORKDIR emscripten-release-bundle/emsdk
 RUN ./emsdk activate latest-fastcomp
 RUN echo 'JAVA = "/usr/bin/java"' >> /home/moonlight/.emscripten
 
-# Compile the source code and prepare the widget directory
-WORKDIR /home/moonlight
-COPY --chown=moonlight . ./moonlight-tizen
+# Copy ONLY the files required for C++ compilation
+COPY --chown=moonlight CMakeLists.txt ./moonlight-tizen/
+COPY --chown=moonlight h264bitstream ./moonlight-tizen/h264bitstream/
+COPY --chown=moonlight libgamestream ./moonlight-tizen/libgamestream/
+COPY --chown=moonlight moonlight-common-c ./moonlight-tizen/moonlight-common-c/
+COPY --chown=moonlight opus ./moonlight-tizen/opus/
+COPY --chown=moonlight ports ./moonlight-tizen/ports/ 
+COPY --chown=moonlight wasm/*.c ./moonlight-tizen/wasm/
+COPY --chown=moonlight wasm/*.cpp ./moonlight-tizen/wasm/
+COPY --chown=moonlight wasm/*.hpp ./moonlight-tizen/wasm/
+COPY --chown=moonlight wasm/dispatcher ./moonlight-tizen/wasm/dispatcher/
+
 RUN cmake \
 	-DCMAKE_TOOLCHAIN_FILE=/home/moonlight/emscripten-release-bundle/emsdk/fastcomp/emscripten/cmake/Modules/Platform/Emscripten.cmake \
 	-G Ninja \
 	-S moonlight-tizen \
 	-B build
 RUN cmake --build build
+
+# Copy the remaining frontend files required for packaging the application into a WGT file
+COPY --chown=moonlight res/ ./moonlight-tizen/res/
+COPY --chown=moonlight wasm/index.html ./moonlight-tizen/wasm/
+COPY --chown=moonlight wasm/platform/ ./moonlight-tizen/wasm/platform/
+COPY --chown=moonlight wasm/static/ ./moonlight-tizen/wasm/static/
+
 RUN cmake --install build --prefix build
 RUN cp moonlight-tizen/res/icon.png build/widget/
 


### PR DESCRIPTION
### Description:
Previously, any modification to the web frontend (HTML, CSS, JS) forced a full recompilation of the C++ codebase during the Docker build. This happened because `COPY . ./moonlight-tizen` copied the entire directory at once, assigning new timestamps to all files - including untouched C++ source files. Ninja detected these updated timestamps and invalidated the build cache, triggering a full rebuild that took approximately 1000 seconds (~15 minutes) on an Apple Silicon MacBook Pro (M1) every single time.

With this change, if a developer only modifies HTML, CSS, or JS files, Docker will utilize the cached layer for the C++ build. The C++ compilation step is skipped entirely, reducing the frontend build time from ~15 minutes to just a few seconds. Rapid iteration on the UI and web platform is now possible without being bottlenecked by the native toolchain.
