### PR TITLE
feat: Replace the snackbar with a proper dialog in DialogMsg and ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ dir.stamp
 # Visual Studio
 *.vs/
 *.vscode/
+.DS_Store

--- a/wasm/platform/messages.js
+++ b/wasm/platform/messages.js
@@ -126,9 +126,8 @@ function handleMessage(msg) {
     // Show transient message as notification
     snackbarLogLong(msg.replace('TransientMsg: ', ''));
   } else if (msg.indexOf('DialogMsg: ') === 0) {
-    // Show dialog message as notification
-    // FIXME: Really use a dialog
-    snackbarLogLong(msg.replace('DialogMsg: ', ''));
+    // Show dialog message using the warning dialog
+    warningDialog('Warning', msg.replace('DialogMsg: ', ''));
   } else if (msg === 'displayVideo') {
     // Show the video stream now
     $('#listener').addClass('fullscreen');


### PR DESCRIPTION
### Description:
Replace the snackbar fallback for "DialogMsg:" with a proper warningDialog('Warning', msg) call to show dialog warnings (remove FIXME comment and previous snackbarLogLong usage).
