### PR TITLE
fix: Duplicate PIN dialogs and suppress timeout errors when canceling pairing

### DIFF
--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -13,6 +13,8 @@ var myUniqueid = '0123456789ABCDEF'; // Use the same UID as other Moonlight clie
 var api; // The `api` should only be set if we're in a host-specific screen, on the initial screen it should always be null
 var isInGame = false; // Flag indicating whether the game has started, initial value is false
 var isDialogOpen = false; // Flag indicating whether the dialog is open, initial value is false
+var isPairingInProgress = false; // Flag indicating whether a pairing process is in progress, initial value is false
+var wasPairingCanceled = false; // Flag indicating whether the current pairing process was canceled by the user, initial value is false
 var isGamepadActive = false; // Flag indicating whether the gamepad input is active, initial value is false
 var isClickPrevented = false; // Flag indicating whether the click event should be prevented, initial value is false
 var resFpsWarning = false; // Flag indicating whether the video resolution and frame rate warning message has shown, initial value is false
@@ -392,6 +394,11 @@ function restoreUiAfterWasmLoad() {
 }
 
 function hostChosen(host) {
+  if (isPairingInProgress) {
+    snackbarLogLong('A pairing request is currently in progress. Please wait for it to timeout or finish before trying again.');
+    return;
+  }
+
   // If the host is already offline or fails to connect, notify the user.
   if (!host.online) {
     // Let the user know what to do to bring the host back online and until then, we'll be back to the previous view.
@@ -812,10 +819,14 @@ function pairingDialog(nvhttpHost, onSuccess, onFailure) {
     isDialogOpen = true;
     Navigation.push(Views.PairingDialog);
 
+    isPairingInProgress = true;
+    wasPairingCanceled = false;
+
     // Cancel the operation if the Cancel button is pressed
     $('#cancelPairing').off('click');
     $('#cancelPairing').on('click', function() {
       console.log('%c[index.js, pairingDialog]', 'color: green;', 'Closing app dialog and returning.');
+      wasPairingCanceled = true;
       pairingOverlay.style.display = 'none';
       pairingDialog.close();
       isDialogOpen = false;
@@ -824,6 +835,7 @@ function pairingDialog(nvhttpHost, onSuccess, onFailure) {
 
     console.log('%c[index.js, pairingDialog]', 'color: green;', 'Sending pairing request to ' + nvhttpHost.hostname + ' with PIN ' + randomNumber);
     nvhttpHost.pair(randomNumber).then(function() {
+      isPairingInProgress = false;
       snackbarLog('Successfully paired with ' + nvhttpHost.hostname);
       // Close the dialog if the pairing was successful
       console.log('%c[index.js, pairingDialog]', 'color: green;', 'Closing app dialog and returning.');
@@ -833,6 +845,11 @@ function pairingDialog(nvhttpHost, onSuccess, onFailure) {
       Navigation.pop();
       onSuccess();
     }, function(failedPairing) {
+      isPairingInProgress = false;
+      if (wasPairingCanceled) {
+        console.log('%c[index.js, pairingDialog]', 'color: green;', 'Ignored pairing failure due to cancellation.');
+        return;
+      }
       console.error('%c[index.js, pairingDialog]', 'color: green;', 'Error: Failed API object:\n', nvhttpHost, '\n' + nvhttpHost.toString()); // Logging both object (for console) and toString-ed object (for text logs)
       snackbarLog('Failed to pair with ' + nvhttpHost.hostname);
       // If the host is already in a streaming session or failed during pairing,


### PR DESCRIPTION
# Pull Request Template

Please fill out this template as completely as possible to help the maintainer review your PR efficiently.

## Description

Fixes an issue where clicking the "Cancel" button on the pairing PIN dialog caused subsequent pairing attempts to queue up behind the blocked C++ background process, resulting in the PIN dialog unexpectedly reappearing on its own up to 60 seconds later.

### Why is this necessary?
The underlying C++ process (handling `libgamestream`) performs pairing via a synchronous HTTP request. Because of this, the C++ Web Worker remains completely blocked waiting for the host PC to respond, even if the user closes the PIN dialog on the TV screen. 
Previously, if the user clicked "Cancel" and then tried clicking the host again, a new pairing request would get queued. Once the first request timed out (after ~60s), the queued request would execute, popping the PIN dialog back up without any user interaction and showing misleading timeout errors.

### How was it fixed?
Added `isPairingInProgress` and `wasPairingCanceled` state flags in `index.js` to manage the UI state independently from the blocked worker:
- **Prevent duplicate queuing:** If a pairing request is already running in the background, clicking the host again will show a warning toast rather than queuing a second request.
- **Silent timeout handling:** If the user clicks "Cancel", we suppress the "Failed to pair" error and do not reopen the dialog when the inevitable 60-second timeout finally occurs, keeping the UI clean.

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Please describe how you tested your changes:
- TV model: UN43T5300AGXZD
- Tizen version: 5.5
- Steps to test the change:

1. Open Moonlight Tizen and click on an unpaired PC to initiate the pairing process.
2. When the PIN dialog appears on the TV screen, **do not** enter the PIN on your PC. 
3. Instead, click the **"Cancel"** button on the TV dialog.
4. **Verify Blocking:** Immediately try to click the PC icon again. Ensure a warning toast appears (*"A pairing request is currently in progress..."*) and that a second PIN dialog does **not** pop up.
5. **Verify Silent Timeout:** Wait for about 60 seconds without clicking anything. Ensure that no random "Failed to pair" errors or PIN dialogs pop up when the background process finally times out.
6. **Verify Re-pairing:** After the 60 seconds have passed, click the PC icon again. Ensure the PIN dialog successfully opens and that you can pair normally by typing the PIN into your PC.

Include screenshots or logs if applicable.

---

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have tested my changes locally on my device
- [X] I have made corresponding changes to the documentation
- [X] I have added comments, particularly in hard-to-understand areas
- [X] No unexpected issues or behavior were introduced
- [X] The project builds successfully with no warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
