### PR TITLE
fix: Generate random unique ID to prevent Sunshine pairing failures

### DIFF
--- a/wasm/main.cpp
+++ b/wasm/main.cpp
@@ -8,6 +8,8 @@
 #include <pairing.h>
 #include <iostream>
 
+extern char* g_UniqueId;
+
 #include <emscripten.h>
 #include <emscripten/html5.h>
 
@@ -509,7 +511,9 @@ void stun(int callbackId) {
   g_Instance->STUN(callbackId);
 }
 
-void pair(int callbackId, std::string serverMajorVersion, std::string address, int httpPort, std::string randomNumber) {
+void pair(int callbackId, std::string serverMajorVersion, std::string address, int httpPort, std::string randomNumber, std::string uniqueId) {
+  if (g_UniqueId) free(g_UniqueId);
+  g_UniqueId = strdup(uniqueId.c_str());
   g_Instance->Pair(callbackId, serverMajorVersion, address, httpPort, randomNumber);
 }
 

--- a/wasm/main.cpp
+++ b/wasm/main.cpp
@@ -512,7 +512,9 @@ void stun(int callbackId) {
 }
 
 void pair(int callbackId, std::string serverMajorVersion, std::string address, int httpPort, std::string randomNumber, std::string uniqueId) {
-  if (g_UniqueId) free(g_UniqueId);
+  if (g_UniqueId) {
+    free(g_UniqueId);
+  }
   g_UniqueId = strdup(uniqueId.c_str());
   g_Instance->Pair(callbackId, serverMajorVersion, address, httpPort, randomNumber);
 }

--- a/wasm/moonlight_wasm.hpp
+++ b/wasm/moonlight_wasm.hpp
@@ -296,7 +296,7 @@ MessageResult stopStream();
 
 void toggleStats();
 void stun(int callbackId);
-void pair(int callbackId, std::string serverMajorVersion, std::string address, int httpPort, std::string randomNumber);
+void pair(int callbackId, std::string serverMajorVersion, std::string address, int httpPort, std::string randomNumber, std::string uniqueId);
 void wakeOnLan(int callbackId, std::string macAddress);
 
 EM_BOOL handleKeyDown(int eventType, const EmscriptenKeyboardEvent* keyEvent, void* userData);

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -9,7 +9,7 @@ var isHdrCapable = webapis.avinfo.isHdrTvSupport(); // Check if the device suppo
 var hosts = {}; // Hosts is an associative array of NvHTTP objects, keyed by server UID
 var activePolls = {}; // Hosts currently being polled. An associated array of polling IDs, keyed by server UID
 var pairingCert; // Loads the generated certificate
-var myUniqueid = '0123456789ABCDEF'; // Use the same UID as other Moonlight clients to allow them to quit each other's games
+var myUniqueid;
 var api; // The `api` should only be set if we're in a host-specific screen, on the initial screen it should always be null
 var isInGame = false; // Flag indicating whether the game has started, initial value is false
 var isDialogOpen = false; // Flag indicating whether the dialog is open, initial value is false
@@ -3605,13 +3605,12 @@ function loadHTTPCertsCb() {
     }
 
     getData('uniqueid', function(savedUniqueid) {
-      // See comment on myUniqueid
-      /*if (savedUniqueid.uniqueid != null) { // We have a saved uniqueid
+      if (savedUniqueid && savedUniqueid.uniqueid != null) { // We have a saved uniqueid
         myUniqueid = savedUniqueid.uniqueid;
       } else {
         myUniqueid = uniqueid();
         storeData('uniqueid', myUniqueid, null);
-      }*/
+      }
 
       if (!pairingCert) { // We couldn't load a cert. Let's attempt to generate a new one.
         console.warn('%c[index.js, loadHTTPCertsCb]', 'color: green;', 'Warning: Local certificate not found! Generating a new one...');

--- a/wasm/static/js/utils.js
+++ b/wasm/static/js/utils.js
@@ -91,6 +91,7 @@ function NvHTTP(address, clientUid, userEnteredAddress = '', macAddress) {
   this.httpPort = 0;
   this.externalPort = 0;
   this.clientUid = clientUid;
+  this.isNvidiaServerSoftware = false;
   this.serverUid = '';
   this.ppkstr = null;
   this._pollCount = 0;
@@ -135,6 +136,10 @@ function _base64ToArrayBuffer(base64) {
 }
 
 NvHTTP.prototype = {
+  getUid: function() {
+    return this.isNvidiaServerSoftware ? '0123456789ABCDEF' : this.clientUid;
+  },
+
   // Refreshes the server info using the base URL. This is useful for testing whether we can successfully ping a host at the base URL
   refreshServerInfo: function() {
     if (this.ppkstr == null) {
@@ -389,6 +394,7 @@ NvHTTP.prototype = {
     var serverStatus = $root.find('state').text().trim();
     if (serverStatus) {
       this.serverState = serverStatus;
+      this.isNvidiaServerSoftware = serverStatus.indexOf('MJOLNIR') !== -1;
     }
 
     // GFE 2.8 started keeping current game set to the last game played. As a result, it no longer
@@ -592,11 +598,11 @@ NvHTTP.prototype = {
         return true;
       }
       return sendMessage('pair', [
-        this.serverMajorVersion.toString(), this.address, this.httpPort, randomNumber
+        this.serverMajorVersion.toString(), this.address, this.httpPort, randomNumber, this.getUid()
       ]).then(function(ppkstr) {
         this.ppkstr = ppkstr;
         return sendMessage('openUrl', [
-          this._baseUrlHttps + '/pair?uniqueid=' + this.clientUid + '&devicename=roth&updateState=1&phrase=pairchallenge', this.ppkstr, false
+          this._baseUrlHttps + '/pair?uniqueid=' + this.getUid() + '&devicename=roth&updateState=1&phrase=pairchallenge', this.ppkstr, false
         ]).then(function(ret) {
           $xml = this._parseXML(ret);
           this.paired = $xml.find('paired').html() == '1';
@@ -611,7 +617,7 @@ NvHTTP.prototype = {
   },
 
   _buildUidStr: function() {
-    return 'uniqueid=' + this.clientUid + '&uuid=' + guuid();
+    return 'uniqueid=' + this.getUid() + '&uuid=' + guuid();
   },
 
   _parseXML: function(xmlData) {

--- a/wasm/static/js/utils.js
+++ b/wasm/static/js/utils.js
@@ -91,7 +91,6 @@ function NvHTTP(address, clientUid, userEnteredAddress = '', macAddress) {
   this.httpPort = 0;
   this.externalPort = 0;
   this.clientUid = clientUid;
-  this.isNvidiaServerSoftware = false;
   this.serverUid = '';
   this.ppkstr = null;
   this._pollCount = 0;
@@ -105,6 +104,7 @@ function NvHTTP(address, clientUid, userEnteredAddress = '', macAddress) {
   this.gfeVersion = '';
   this.serverMajorVersion = 0;
   this.serverState = '';
+  this.isNvidiaServerSoftware = false;
   this.gputype = '';
   this.supportedDisplayModes = {}; // key: y-resolution:x-resolution, value: array of supported frame rates
 
@@ -310,6 +310,7 @@ NvHTTP.prototype = {
     string += 'gfe version: ' + this.gfeVersion + '\r\n';
     string += 'server major version: ' + this.serverMajorVersion + '\r\n';
     string += 'server state: ' + this.serverState + '\r\n';
+    string += 'nvidia server software: ' + this.isNvidiaServerSoftware + '\r\n';
     string += 'gpu type: ' + this.gputype + '\r\n';
     string += 'supported display modes: ' + '\r\n';
 
@@ -394,7 +395,8 @@ NvHTTP.prototype = {
     var serverStatus = $root.find('state').text().trim();
     if (serverStatus) {
       this.serverState = serverStatus;
-      this.isNvidiaServerSoftware = serverStatus.indexOf('MJOLNIR') !== -1;
+      // Detect GFE by its historical "MJOLNIR" codename, which was never used by any third-party server
+      this.isNvidiaServerSoftware = serverStatus.includes('MJOLNIR');
     }
 
     // GFE 2.8 started keeping current game set to the last game played. As a result, it no longer


### PR DESCRIPTION
## Description
This PR resolves a cryptographic pairing bug where Moonlight Tizen would fail to pair with Sunshine (returning `<paired>0</paired>` on the `clientpairingsecret` step).

**Root Cause**
Previously, the `myUniqueid` variable was hardcoded to `0123456789ABCDEF` for all sessions to theoretically allow clients to quit each other's games. However, Sunshine indexes its pending pairing sessions in memory by the client's `uniqueid`. 

If a pairing attempt was aborted (e.g., the TV UI froze or the user restarted the app) and the user subsequently cleared the TV app's data to restart the process, Tizen would generate a new cryptographic certificate but reuse the same hardcoded `0123456789ABCDEF` ID. When the new pairing request reached Sunshine, it would find the stale session for that ID and refuse to overwrite the old certificate. Ultimately, Sunshine would attempt to verify the new signature using the old certificate, causing a mathematical failure.

**Fix**
- Uncommented the block in `wasm/platform/index.js` that generates a random 16-character hex `uniqueid` and saves it to IndexedDB (matching the behavior of standard Moonlight clients like Android and Qt).
- Removed the hardcoded fallback `var myUniqueid = '0123456789ABCDEF';` and its associated comment.

By generating a random `uniqueid` on a fresh install, Sunshine will always treat it as a brand-new pairing session, cleanly bypassing the stale session bug.

---

## Type of Change

Please select the relevant option(s):
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Please describe how you tested your changes:
- TV model: UN43T5300AGXZD
- Tizen version: 5.5
- Steps to test the change:

1. Ensure Sunshine is running on the host PC.
2. Open Moonlight Tizen and attempt to pair with the PC.
3. While Sunshine is waiting for the PIN to be entered on the host, forcibly close the TV app or abort the process.
4. Clear the Moonlight Tizen app data on the TV (this forces it to generate a new cryptographic certificate).
5. Open Moonlight Tizen again and attempt to pair a second time.
6. **Without this PR:** Sunshine will silently reuse the stale pairing session in its memory, fail the final cryptographic handshake, and the TV will show a pairing failure (despite Sunshine's Web UI saying "Success").
7. **With this PR:** The TV will generate a new random Unique ID along with its new certificate. Sunshine will treat it as a completely new pairing session, and the pairing will succeed.

---

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have tested my changes locally on my device
- [X] I have made corresponding changes to the documentation
- [X] I have added comments, particularly in hard-to-understand areas
- [X] No unexpected issues or behavior were introduced
- [X] The project builds successfully with no warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
