### PR TITLE
fix: NvHTTP object revival bug causing 'undefined' URL requests

### DIFF
--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -3658,6 +3658,7 @@ function loadHTTPCertsCb() {
         hosts = previousValue.hosts != null ? previousValue.hosts : {};
         for (var hostUID in hosts) { // Programmatically add each new host
           var revivedHost = new NvHTTP(hosts[hostUID].address, myUniqueid, hosts[hostUID].userEnteredAddress, hosts[hostUID].macAddress);
+          Object.assign(revivedHost, hosts[hostUID]);
           revivedHost.httpPort = hosts[hostUID].httpPort || ((hosts[hostUID].httpsPort || 47984) + 5);
           revivedHost.httpsPort = hosts[hostUID].httpsPort || (revivedHost.httpPort - 5);
           revivedHost.externalPort = hosts[hostUID].externalPort || revivedHost.httpPort;

--- a/wasm/static/js/utils.js
+++ b/wasm/static/js/utils.js
@@ -80,7 +80,7 @@ String.prototype.toHex = function() {
 }
 
 function NvHTTP(address, clientUid, userEnteredAddress = '', macAddress) {
-  console.log('%c[utils.js, NvHTTP]', 'color: gray;', 'NvHTTP Object: \n' + this);
+  // Constructor start
   this.hostname = address;
   this.address = address;
   this.userEnteredAddress = userEnteredAddress; // if the user entered an address, we keep it on hand to try when polling
@@ -108,6 +108,7 @@ function NvHTTP(address, clientUid, userEnteredAddress = '', macAddress) {
   this.supportedDisplayModes = {}; // key: y-resolution:x-resolution, value: array of supported frame rates
 
   _self = this;
+  console.log('%c[utils.js, NvHTTP]', 'color: gray;', 'NvHTTP Object: \n' + this);
 };
 
 function _arrayBufferToBase64(buffer) {


### PR DESCRIPTION
## Description
* Fixed a deserialization bug where newly revived `NvHTTP` objects failed to inherit properties from IndexedDB properly (#87).

During application boot-up, the client retrieves saved hosts from its IndexedDB to instantiate them back into `NvHTTP` connection objects. The client previously neglected to copy essential internal attributes from the JSON object back into the class instance—most notably, `_baseUrlHttp` and `_baseUrlHttps`. 

Consequently, when `host.refreshServerInfo()` polled the local network to check if the host was online, the URL constructed for the `openUrl` command would evaluate to `undefined/serverinfo?...`. This missing base URL string prompted the WebAssembly cURL client to attempt DNS resolution on a domain literally named `undefined`, returning an immediate `Couldn't resolve host name` failure and permanently marking the host as offline.

By assigning the missing properties from the raw database entry directly back into the newly revived `NvHTTP` object, the URL builds properly and polls the PC normally.

* Fixed a cosmetic logging quirk in the `NvHTTP` constructor that printed undefined variables to the console.

In `wasm/static/js/utils.js`, the `NvHTTP` constructor was triggering a `console.log` of itself immediately at the start of the block, *before* any properties were actually populated. Because this triggered the object's `toString()` method prematurely, the console erroneously flooded with `undefined` values for all class properties (e.g., `host name: undefined`, `host address: undefined`), causing confusion when debugging. 

The logging statement was moved to the end of the constructor so it accurately reflects the instantiated object's values.

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Please describe how you tested your changes:
- TV model: UN43T5300AGXZD
- Tizen version: 5.5
- Steps to test the change:

Include screenshots or logs if applicable.

---

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have tested my changes locally on my device
- [X] I have made corresponding changes to the documentation
- [X] I have added comments, particularly in hard-to-understand areas
- [X] No unexpected issues or behavior were introduced
- [X] The project builds successfully with no warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

The primary reason the TV immediately thinks the host is offline is a JavaScript deserialization bug in the Moonlight Tizen client itself ([moonlight.debug.mode.2.txt](https://github.com/user-attachments/files/29410966/moonlight.debug.mode.2.txt)).

1. The Moonlight app successfully reads your saved host configuration from its internal database (`IndexedDB`), which correctly contains your IP address (`192.168.1.17`) and ports.
2. However, when the app tries to initialize the `NvHTTP` connection object, it fails to map this data, resulting in all properties - including the host name and address - becoming `undefined`.
3. Because the base URL is missing, the WebAssembly cURL module literally attempts to ping a domain named "undefined" (`undefined/serverinfo?uniqueid=...`).
4. Your network obviously cannot resolve "undefined", causing cURL to immediately throw a `Couldn't resolve host name error`.