### PR TITLE
feat: Add center status icons for hosts to better identify host status using an indicator

### DIFF
--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -217,10 +217,15 @@ function delayedNavigation(callback) {
   // Set a new navigation timeout with the provided callback and delay
   navigationTimeout = setTimeout(callback, NAVIGATION_DELAY);
 }
+
+// Updates the host status indicator based on the host's online and paired status
 function updateHostStatusIndicator(host) {
   var indicator = document.querySelector('#host-status-' + host.serverUid);
-  if (!indicator) return;
-
+  // If the indicator element is not found, exit the function early
+  if (!indicator) {
+    return;
+  }
+  // Set the appropriate status indicator based on the host status
   if (host.online === undefined || host.online === null) {
     indicator.style.display = 'none';
   } else if (!host.online) {
@@ -234,7 +239,6 @@ function updateHostStatusIndicator(host) {
     indicator.innerHTML = '';
   }
 }
-
 
 function beginBackgroundPollingOfHost(host) {
   // Assign methods of NvHTTP to the host object
@@ -963,6 +967,12 @@ function addHostToGrid(host, ismDNSDiscovered) {
     'aria-label': host.hostname + ' menu'
   });
 
+  // Create the host center icon to indicate the host's status (online/offline/unpaired)
+  var hostStatusIndicator = $('<i>', {
+    id: 'host-status-' + host.serverUid,
+    class: 'material-icons host-center-icon'
+  });
+
   // Append the host text to the host title wrapper
   hostTitle.append(hostText);
 
@@ -984,12 +994,6 @@ function addHostToGrid(host, ismDNSDiscovered) {
   // Append the host menu button to the host container
   hostContainer.append(hostMenu);
 
-  // Create the host center icon
-  var hostStatusIndicator = $('<i>', {
-    id: 'host-status-' + host.serverUid,
-    class: 'material-icons host-center-icon'
-  });
-  
   // Append the host status indicator to the host container
   hostContainer.append(hostStatusIndicator);
 

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -217,6 +217,24 @@ function delayedNavigation(callback) {
   // Set a new navigation timeout with the provided callback and delay
   navigationTimeout = setTimeout(callback, NAVIGATION_DELAY);
 }
+function updateHostStatusIndicator(host) {
+  var indicator = document.querySelector('#host-status-' + host.serverUid);
+  if (!indicator) return;
+
+  if (host.online === undefined || host.online === null) {
+    indicator.style.display = 'none';
+  } else if (!host.online) {
+    indicator.style.display = 'block';
+    indicator.innerHTML = 'warning';
+  } else if (host.online && !host.paired) {
+    indicator.style.display = 'block';
+    indicator.innerHTML = 'lock';
+  } else {
+    indicator.style.display = 'none';
+    indicator.innerHTML = '';
+  }
+}
+
 
 function beginBackgroundPollingOfHost(host) {
   // Assign methods of NvHTTP to the host object
@@ -231,6 +249,7 @@ function beginBackgroundPollingOfHost(host) {
     if (host.online) {
       // If the host is online, show it as active
       hostCell.classList.remove('host-cell-inactive');
+      updateHostStatusIndicator(host);
       // The host was already online, so start polling in the background now
       activePolls[host.serverUid] = window.setInterval(function() {
         // Every 5 seconds, poll at the address to check for any status changes
@@ -241,11 +260,13 @@ function beginBackgroundPollingOfHost(host) {
           } else {
             hostCell.classList.add('host-cell-inactive');
           }
+          updateHostStatusIndicator(returnedHost);
         });
       }, 5000);
     } else {
       // If the host is offline, show it as inactive
       hostCell.classList.add('host-cell-inactive');
+      updateHostStatusIndicator(host);
       // The host was offline, so poll immediately to check the host's status
       host.pollServer(function(returnedHost) {
         // Check if the host is currently online
@@ -254,6 +275,7 @@ function beginBackgroundPollingOfHost(host) {
         } else {
           hostCell.classList.add('host-cell-inactive');
         }
+        updateHostStatusIndicator(returnedHost);
         // Now that the initial poll is done, start the background polling
         activePolls[host.serverUid] = window.setInterval(function() {
           // Every 5 seconds, poll at the address to check for any status changes
@@ -264,6 +286,7 @@ function beginBackgroundPollingOfHost(host) {
             } else {
               hostCell.classList.add('host-cell-inactive');
             }
+            updateHostStatusIndicator(returnedHost);
           });
         }, 5000);
       });
@@ -960,6 +983,18 @@ function addHostToGrid(host, ismDNSDiscovered) {
 
   // Append the host menu button to the host container
   hostContainer.append(hostMenu);
+
+  // Create the host center icon
+  var hostStatusIndicator = $('<i>', {
+    id: 'host-status-' + host.serverUid,
+    class: 'material-icons host-center-icon'
+  });
+  
+  // Append the host status indicator to the host container
+  hostContainer.append(hostStatusIndicator);
+
+  // Set initial status
+  updateHostStatusIndicator(host);
 
   // Attach the click event listener to the host container
   hostContainer.off('click');

--- a/wasm/static/css/style.css
+++ b/wasm/static/css/style.css
@@ -562,6 +562,16 @@ body {
     transform: scale(1.3);
     box-shadow: 0 1px 4px rgba(0, 163, 198, 0.4);
 }
+.host-center-icon {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -60%);
+    font-size: 32px;
+    color: #fff;
+    text-shadow: 0 0 5px rgba(0,0,0,0.8);
+    z-index: 5;
+}
 /* =============================
    Games Section
 ============================= */


### PR DESCRIPTION
### Description
This PR revamps the host status indicator to align with the visual style of the official [Android](https://play.google.com/store/apps/details?id=com.limelight&hl=pt_BR) and [Flathub](https://flathub.org/pt-BR/apps/com.moonlight_stream.Moonlight) Moonlight implementations. 

The host grid now leverages central Material Design overlay icons over the host's monitor graphic to communicate connection state:
- **Offline**: Displays a warning triangle icon (`warning`).
- **Online but Unpaired**: Displays a padlock icon (`lock`).
- **Online and Paired**: Displays the clean monitor icon (no overlay).

### Changes Made
- **`wasm/static/css/style.css`**: Added a new `.host-center-icon` class. This perfectly centers a 32px Material Icon within the monitor graphic, applying a text shadow for contrast.
- **`wasm/platform/index.js`**: Refactored `addHostToGrid` to inject a Material Icon `<i>` element. Updated the background polling logic in `updateHostStatusIndicator` to explicitly handle the `!host.online` and `host.online && !host.paired` states, swapping out the DOM element's inner HTML (`lock`, `warning`, or empty) and visibility accordingly.

---

## Type of Change

Please select the relevant option(s):
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Please describe how you tested your changes:
- TV model: UN43T5300AGXZD
- Tizen version: 5.5
- Steps to test the change:

Include screenshots or logs if applicable.

---

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have tested my changes locally on my device
- [X] I have made corresponding changes to the documentation
- [X] I have added comments, particularly in hard-to-understand areas
- [X] No unexpected issues or behavior were introduced
- [X] The project builds successfully with no warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
