### PR TITLE
fix: App list selection race condition where the first app was focused before the app list was fully loaded

### DIFF
--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -442,28 +442,26 @@ function hostChosen(host) {
     pairingDialog(host, function() {
       // After pairing the host, save the host object, show the apps, and navigate to the Apps view
       saveHosts();
-      showApps(host);
       Navigation.push(Views.Apps);
-      setTimeout(() => {
+      showApps(host).then(() => {
         // Scroll to the current game row
         Navigation.switch();
         // Switch to Apps view
         Navigation.change(Views.Apps);
-      }, 1500);
+      }).catch(console.error);
     }, function() {
       // Start polling the host after pairing flow
       startPollingHosts();
     });
   } else {
     // But if the host is already paired and online, then we show the apps and navigate to the Apps view as usual.
-    showApps(host);
     Navigation.push(Views.Apps);
-    setTimeout(() => {
+    showApps(host).then(() => {
       // Scroll to the current game row
       Navigation.switch();
       // Switch to Apps view
       Navigation.change(Views.Apps);
-    }, 1500);
+    }).catch(console.error);
   }
 }
 
@@ -2079,13 +2077,15 @@ function showAppsMode() {
 
 // Show the Apps grid
 function showApps(host) {
-  // Safety checking should happen before attempting to show the app list
-  if (!host || !host.paired) {
-    console.error('%c[index.js, showApps]', 'color: green;', 'Error: Unable to initialize the host properly! Host object: ', host);
-    return;
-  } else {
-    console.log('%c[index.js, showApps]', 'color: green;', 'Current host object: \n', host, '\n' + host.toString()); // Logging both object (for console) and toString-ed object (for text logs)
-  }
+  return new Promise((resolve, reject) => {
+    // Safety checking should happen before attempting to show the app list
+    if (!host || !host.paired) {
+      console.error('%c[index.js, showApps]', 'color: green;', 'Error: Unable to initialize the host properly! Host object: ', host);
+      reject('Unable to initialize the host properly');
+      return;
+    } else {
+      console.log('%c[index.js, showApps]', 'color: green;', 'Current host object: \n', host, '\n' + host.toString()); // Logging both object (for console) and toString-ed object (for text logs)
+    }
 
   // Stop navigation before showing the loading screen
   Navigation.stop();
@@ -2213,6 +2213,9 @@ function showApps(host) {
         boxArtPlaceholderImg.onload = e => boxArtPlaceholderImg.classList.add('fade-in');
         $(gameContainer).append(boxArtPlaceholderImg);
       });
+      // Navigate to the Apps view
+      showAppsMode();
+      resolve();
     }, function(failedAppList) {
       // Hide the spinner if the host has failed to retrieve the app list
       $('#wasmSpinner').hide();
@@ -2226,11 +2229,13 @@ function showApps(host) {
       errorAppListImg.src = 'static/res/applist_error.svg';
       $('#game-grid').html(errorAppListImg);
       snackbarLogLong('Unable to retrieve your list of apps at this time. Please refresh the list of apps or try again later!');
-    });
 
-    // Navigate to the Apps view
-    showAppsMode();
+      // Navigate to the Apps view
+      showAppsMode();
+      reject(failedAppList);
+    });
   }, 500);
+  });
 }
 
 // Show a confirmation with the Quit App dialog before stopping the running app
@@ -2462,13 +2467,12 @@ function startGame(host, appID) {
           if (status_code != 200) {
             $('#loadingSpinnerMessage').text('');
             snackbarLogLong('Error ' + status_code + ': ' + status_message);
-            showApps(host);
-            setTimeout(() => {
+            showApps(host).then(() => {
               // Scroll to the current game row
               Navigation.switch();
               // Switch to Apps view
               Navigation.change(Views.Apps);
-            }, 1500);
+            });
             return;
           }
           // Start stream request
@@ -2482,13 +2486,12 @@ function startGame(host, appID) {
         }, function(failedResumeApp) {
           console.error('%c[index.js, startGame]', 'color: green;', 'Error: Failed to resume app with id: ' + appID + '\n Returned error was: ' + failedResumeApp + '!');
           snackbarLog('Failed to resume ' + appToStart.title);
-          showApps(host);
-          setTimeout(() => {
+          showApps(host).then(() => {
             // Scroll to the current game row
             Navigation.switch();
             // Switch to Apps view
             Navigation.change(Views.Apps);
-          }, 1500);
+          });
           return;
         });
       }
@@ -2516,13 +2519,12 @@ function startGame(host, appID) {
           }
           $('#loadingSpinnerMessage').text('');
           snackbarLogLong('Error ' + status_code + ': ' + status_message);
-          showApps(host);
-          setTimeout(() => {
+          showApps(host).then(() => {
             // Scroll to the current game row
             Navigation.switch();
             // Switch to Apps view
             Navigation.change(Views.Apps);
-          }, 1500);
+          });
           return;
         }
         // Start stream request
@@ -2536,13 +2538,12 @@ function startGame(host, appID) {
       }, function(failedLaunchApp) {
         console.error('%c[index.js, startGame]', 'color: green;', 'Error: Failed to launch app with id: ' + appID + '\n Returned error was: ' + failedLaunchApp + '!');
         snackbarLog('Failed to launch ' + appToStart.title + '.');
-        showApps(host);
-        setTimeout(() => {
+        showApps(host).then(() => {
           // Scroll to the current game row
           Navigation.switch();
           // Switch to Apps view
           Navigation.change(Views.Apps);
-        }, 1500);
+        });
         return;
       });
     });
@@ -2571,8 +2572,9 @@ function stopGame(host, callbackFunction) {
         snackbarLog('Successfully quit ' + appTitle);
         host.refreshServerInfo().then(function(ret3) {
           // Refresh to show no app is currently running
-          showApps(host);
-          if (typeof(callbackFunction) === "function") callbackFunction();
+          showApps(host).finally(() => {
+            if (typeof(callbackFunction) === "function") callbackFunction();
+          });
         }, function(failedRefreshInfo2) {
           console.error('%c[index.js, stopGame]', 'color: green;', 'Error: Failed to refresh server info! Returned error was: ' + failedRefreshInfo2 + '! Failed server was: ' + '\n', host, '\n' + host.toString()); // Logging both object (for console) and toString-ed object (for text logs)
         });

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -2087,154 +2087,154 @@ function showApps(host) {
       console.log('%c[index.js, showApps]', 'color: green;', 'Current host object: \n', host, '\n' + host.toString()); // Logging both object (for console) and toString-ed object (for text logs)
     }
 
-  // Stop navigation before showing the loading screen
-  Navigation.stop();
+    // Stop navigation before showing the loading screen
+    Navigation.stop();
 
-  // Hide the main header before showing a loading screen
-  $('#main-header').children().hide();
-  $('#main-header').css({'backgroundColor': 'transparent', 'boxShadow': 'none'});
-  $('#host-grid, #settings-list').hide();
+    // Hide the main header before showing a loading screen
+    $('#main-header').children().hide();
+    $('#main-header').css({'backgroundColor': 'transparent', 'boxShadow': 'none'});
+    $('#host-grid, #settings-list').hide();
 
-  // Show a spinner while the app list loads
-  $('#wasmSpinner').css('display', 'inline-block');
-  $('#wasmSpinnerLogo').hide();
-  $('#wasmSpinnerMessage').text('Loading Apps...');
+    // Show a spinner while the app list loads
+    $('#wasmSpinner').css('display', 'inline-block');
+    $('#wasmSpinnerLogo').hide();
+    $('#wasmSpinnerMessage').text('Loading Apps...');
 
-  // Remove all game container elements from the game grid and from any other div elements
-  $('#game-grid .game-container').remove();
-  $('div.game-container').remove();
+    // Remove all game container elements from the game grid and from any other div elements
+    $('#game-grid .game-container').remove();
+    $('div.game-container').remove();
 
-  setTimeout(() => {
-    host.getAppList().then(function(appList) {
-      // Hide the spinner after the host has successfully retrieved the app list
-      $('#wasmSpinner').hide();
+    setTimeout(() => {
+      host.getAppList().then(function(appList) {
+        // Hide the spinner after the host has successfully retrieved the app list
+        $('#wasmSpinner').hide();
 
-      // Show the main header after the loading screen is complete
-      $('#main-header').children().show();
-      $('#main-header').css({'backgroundColor': '#333846', 'boxShadow': '0 0 4px 0 rgba(0, 0, 0, 1)'});
+        // Show the main header after the loading screen is complete
+        $('#main-header').children().show();
+        $('#main-header').css({'backgroundColor': '#333846', 'boxShadow': '0 0 4px 0 rgba(0, 0, 0, 1)'});
 
-      // Show the game grid section
-      $('#game-grid').show();
+        // Show the game grid section
+        $('#game-grid').show();
 
-      if (appList.length == 0) {
-        console.warn('%c[index.js, showApps]', 'Warning: Your app list is empty. Please add some apps to your list!');
-        var emptyAppListImg = new Image();
-        emptyAppListImg.src = 'static/res/applist_empty.svg';
-        $('#game-grid').html(emptyAppListImg);
-        snackbarLogLong('Your list is currently empty. Please add your favorite apps to the list.');
-        return;
-      }
-
-      // Find the existing switch element
-      const sortAppsListSwitch = document.getElementById('sortAppsListSwitch');
-      // Defines the sort order based on the state of the switch
-      const sortOrder = sortAppsListSwitch.checked ? 'DESC' : 'ASC';
-      // If game grid is populated, sort the app list
-      const sortedAppList = sortTitles(appList, sortOrder);
-
-      sortedAppList.forEach(function(app) {
-        // Double clicking the button will cause multiple box arts to appear.
-        // To mitigate this, we ensure that we don't add a duplicate box art.
-        // This isn't perfect: there's lots of RTTs before the logic prevents anything.
-        if ($('#game-container-' + app.id).length === 0) {
-          // Create the game container with the appropriate attributes for the game card
-          var gameContainer = $('<div>', {
-            id: 'game-container-' + app.id,
-            class: 'game-container mdl-card mdl-shadow--4dp',
-            role: 'link',
-            tabindex: 0,
-            'aria-label': app.title
-          });
-
-          // Create the game cell to serve as a holder for the game box
-          var gameCell = $('<div>', {
-            id: 'game-' + app.id,
-            class: 'mdl-card__title mdl-card--expand'
-          });
-
-          // Create the game title wrapper to hold the game title text
-          var gameTitle = $('<div>', {
-            class: 'game-title mdl-card__title-text'
-          });
-
-          // Create the game text placeholder that will contain the game name
-          var gameText = $('<span>', {
-            class: 'game-text',
-            html: app.title
-          });
-
-          // Append the game text to the game title wrapper
-          gameTitle.append(gameText);
-
-          // Handle animation state based on game title text length
-          if (app.title.length <= 20) {
-            // For game title text of 20 characters or less, disable scrolling text animation
-            gameText.addClass('disable-animation');
-          } else {
-            // For game title text longer than 20 characters, enable scrolling text animation
-            gameText.removeClass('disable-animation');
-          }
-
-          // Append the game title to the game cell
-          gameCell.append(gameTitle);
-
-          // Append the game cell to the game container
-          gameContainer.append(gameCell);
-
-          // Attach the click event listener to the game container
-          gameContainer.off('click');
-          gameContainer.on('click', function() {
-            // Prevent further clicks
-            if (isClickPrevented) {
-              return;
-            }
-            // Block subsequent clicks immediately
-            isClickPrevented = true;
-            // Start the game when the Click key is pressed
-            startGame(host, app.id);
-            // Reset the click flag after 2 second delay
-            setTimeout(() => isClickPrevented = false, 2000);
-          });
-
-          // Append the game container to the game grid
-          $('#game-grid').append(gameContainer);
-
-          // Apply style to the game container to indicate whether the game is active or not
-          setTimeout(() => stylizeBoxArt(host, app.id), 100);
+        if (appList.length == 0) {
+          console.warn('%c[index.js, showApps]', 'Warning: Your app list is empty. Please add some apps to your list!');
+          var emptyAppListImg = new Image();
+          emptyAppListImg.src = 'static/res/applist_empty.svg';
+          $('#game-grid').html(emptyAppListImg);
+          snackbarLogLong('Your list is currently empty. Please add your favorite apps to the list.');
+          return;
         }
-        // Load box art
-        var boxArtPlaceholderImg = new Image();
-        host.getBoxArt(app.id).then(function(resolvedPromise) {
-          boxArtPlaceholderImg.src = resolvedPromise;
-        }, function(failedPromise) {
-          console.error('%c[index.js, showApps]', 'color: green;', 'Error: Failed to retrieve box art for app ID: ' + app.id + '. Returned value was: ' + failedPromise + '. Host object: ', host, '\n' + host.toString()); // Logging both object (for console) and toString-ed object (for text logs)
-          boxArtPlaceholderImg.src = 'static/res/placeholder_error.svg';
+
+        // Find the existing switch element
+        const sortAppsListSwitch = document.getElementById('sortAppsListSwitch');
+        // Defines the sort order based on the state of the switch
+        const sortOrder = sortAppsListSwitch.checked ? 'DESC' : 'ASC';
+        // If game grid is populated, sort the app list
+        const sortedAppList = sortTitles(appList, sortOrder);
+
+        sortedAppList.forEach(function(app) {
+          // Double clicking the button will cause multiple box arts to appear.
+          // To mitigate this, we ensure that we don't add a duplicate box art.
+          // This isn't perfect: there's lots of RTTs before the logic prevents anything.
+          if ($('#game-container-' + app.id).length === 0) {
+            // Create the game container with the appropriate attributes for the game card
+            var gameContainer = $('<div>', {
+              id: 'game-container-' + app.id,
+              class: 'game-container mdl-card mdl-shadow--4dp',
+              role: 'link',
+              tabindex: 0,
+              'aria-label': app.title
+            });
+
+            // Create the game cell to serve as a holder for the game box
+            var gameCell = $('<div>', {
+              id: 'game-' + app.id,
+              class: 'mdl-card__title mdl-card--expand'
+            });
+
+            // Create the game title wrapper to hold the game title text
+            var gameTitle = $('<div>', {
+              class: 'game-title mdl-card__title-text'
+            });
+
+            // Create the game text placeholder that will contain the game name
+            var gameText = $('<span>', {
+              class: 'game-text',
+              html: app.title
+            });
+
+            // Append the game text to the game title wrapper
+            gameTitle.append(gameText);
+
+            // Handle animation state based on game title text length
+            if (app.title.length <= 20) {
+              // For game title text of 20 characters or less, disable scrolling text animation
+              gameText.addClass('disable-animation');
+            } else {
+              // For game title text longer than 20 characters, enable scrolling text animation
+              gameText.removeClass('disable-animation');
+            }
+
+            // Append the game title to the game cell
+            gameCell.append(gameTitle);
+
+            // Append the game cell to the game container
+            gameContainer.append(gameCell);
+
+            // Attach the click event listener to the game container
+            gameContainer.off('click');
+            gameContainer.on('click', function() {
+              // Prevent further clicks
+              if (isClickPrevented) {
+                return;
+              }
+              // Block subsequent clicks immediately
+              isClickPrevented = true;
+              // Start the game when the Click key is pressed
+              startGame(host, app.id);
+              // Reset the click flag after 2 second delay
+              setTimeout(() => isClickPrevented = false, 2000);
+            });
+
+            // Append the game container to the game grid
+            $('#game-grid').append(gameContainer);
+
+            // Apply style to the game container to indicate whether the game is active or not
+            setTimeout(() => stylizeBoxArt(host, app.id), 100);
+          }
+          // Load box art
+          var boxArtPlaceholderImg = new Image();
+          host.getBoxArt(app.id).then(function(resolvedPromise) {
+            boxArtPlaceholderImg.src = resolvedPromise;
+          }, function(failedPromise) {
+            console.error('%c[index.js, showApps]', 'color: green;', 'Error: Failed to retrieve box art for app ID: ' + app.id + '. Returned value was: ' + failedPromise + '. Host object: ', host, '\n' + host.toString()); // Logging both object (for console) and toString-ed object (for text logs)
+            boxArtPlaceholderImg.src = 'static/res/placeholder_error.svg';
+          });
+          boxArtPlaceholderImg.onload = e => boxArtPlaceholderImg.classList.add('fade-in');
+          $(gameContainer).append(boxArtPlaceholderImg);
         });
-        boxArtPlaceholderImg.onload = e => boxArtPlaceholderImg.classList.add('fade-in');
-        $(gameContainer).append(boxArtPlaceholderImg);
+        // Navigate to the Apps view
+        showAppsMode();
+        resolve();
+      }, function(failedAppList) {
+        // Hide the spinner if the host has failed to retrieve the app list
+        $('#wasmSpinner').hide();
+
+        // Show the main header after the loading screen is complete
+        $('#main-header').children().show();
+        $('#main-header').css({'backgroundColor': '#333846', 'boxShadow': '0 0 4px 0 rgba(0, 0, 0, 1)'});
+
+        console.error('%c[index.js, showApps]', 'color: green;', 'Error: Failed to get app list from ' + host.hostname + '. Host object: ', host, '\n' + host.toString()); // Logging both object (for console) and toString-ed object (for text logs)
+        var errorAppListImg = new Image();
+        errorAppListImg.src = 'static/res/applist_error.svg';
+        $('#game-grid').html(errorAppListImg);
+        snackbarLogLong('Unable to retrieve your list of apps at this time. Please refresh the list of apps or try again later!');
+
+        // Navigate to the Apps view
+        showAppsMode();
+        reject(failedAppList);
       });
-      // Navigate to the Apps view
-      showAppsMode();
-      resolve();
-    }, function(failedAppList) {
-      // Hide the spinner if the host has failed to retrieve the app list
-      $('#wasmSpinner').hide();
-
-      // Show the main header after the loading screen is complete
-      $('#main-header').children().show();
-      $('#main-header').css({'backgroundColor': '#333846', 'boxShadow': '0 0 4px 0 rgba(0, 0, 0, 1)'});
-
-      console.error('%c[index.js, showApps]', 'color: green;', 'Error: Failed to get app list from ' + host.hostname + '. Host object: ', host, '\n' + host.toString()); // Logging both object (for console) and toString-ed object (for text logs)
-      var errorAppListImg = new Image();
-      errorAppListImg.src = 'static/res/applist_error.svg';
-      $('#game-grid').html(errorAppListImg);
-      snackbarLogLong('Unable to retrieve your list of apps at this time. Please refresh the list of apps or try again later!');
-
-      // Navigate to the Apps view
-      showAppsMode();
-      reject(failedAppList);
-    });
-  }, 500);
+    }, 500);
   });
 }
 


### PR DESCRIPTION
### Description
Fixes a race condition where the UI navigation logic attempted to select the first app before the app list had fully loaded.

Previously, functions like `hostChosen`, `startGame`, and `stopGame` relied on a hardcoded 1.5-second timeout to wait for the app list to populate. If the network request took longer to finish, the navigation component would crash with a `resolveElement` error because the target elements didn't exist yet.

```js
navigation.js:12 [navigation.js, resolveElement] No target element is provided! undefined
    at resolveElement (navigation.js:12)
    at unmark (navigation.js:111)
    at leave (navigation.js:1470)
    at change (navigation.js:1699)
    at index.js:467
```

### Changes
*   Changed `showApps()` to return a `Promise` that resolves only after the app list is retrieved and its UI elements have been fully injected into the DOM.
*   Updated `hostChosen()` to await the `showApps()` promise instead of using a 1.5-second `setTimeout`.
*   Updated error handlers in `startGame()` to accurately await `showApps()` before navigating to the Apps view.
*   Updated `stopGame()` to use `.finally()` to safely trigger its callback after `showApps()` finishes.
---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Please describe how you tested your changes:
- TV model: UN43T5300AGXZD
- Tizen version: 5.5
- Steps to test the change:

Include screenshots or logs if applicable.

---

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have tested my changes locally on my device
- [X] I have made corresponding changes to the documentation
- [X] I have added comments, particularly in hard-to-understand areas
- [X] No unexpected issues or behavior were introduced
- [X] The project builds successfully with no warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
