### PR TITLE
fix: Host online/offline status detection and app cache clearing

### DIFF
--- a/libgamestream/http.c
+++ b/libgamestream/http.c
@@ -23,10 +23,6 @@
 #include <string.h>
 #include <curl/curl.h>
 
-#ifdef __EMSCRIPTEN__
-#include <emscripten.h>
-#endif
-
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>
 #include <openssl/pem.h>
@@ -83,13 +79,14 @@ static int _progress_callback(void *clientp, double dltotal, double dlnow, doubl
 int http_request(const char* url, const char* ppkstr, PHTTP_DATA data) {
   int ret;
   CURL *curl;
+  const char* real_url = url;
+  char* rewritten_url = NULL;
+  char* resolve_string = NULL;
+  struct curl_slist *resolve_list = NULL;
 
   http_reset_cancel();
 
   curl = curl_easy_init();
-  if (!curl) {
-    return GS_FAILED;
-  }
 
   curl_easy_setopt(curl, CURLOPT_CAINFO, "/curl/ca-bundle.crt");
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, _write_curl);
@@ -105,7 +102,46 @@ int http_request(const char* url, const char* ppkstr, PHTTP_DATA data) {
   curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
   curl_easy_setopt(curl, CURLOPT_SSL_ENABLE_ALPN, 0L);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, data);
-  curl_easy_setopt(curl, CURLOPT_URL, url);
+
+  const char* bracket_start = strchr(url, '[');
+  const char* bracket_end = strchr(url, ']');
+
+  if (bracket_start != NULL && bracket_end != NULL && bracket_end > bracket_start) {
+    int ipv6_len = bracket_end - bracket_start - 1;
+    char ipv6_raw[128] = {0};
+    if (ipv6_len < sizeof(ipv6_raw)) {
+      strncpy(ipv6_raw, bracket_start + 1, ipv6_len);
+    }
+    
+    const char* port_and_path = bracket_end + 1;
+    
+    int scheme_len = bracket_start - url;
+    char scheme[32] = {0};
+    if (scheme_len < sizeof(scheme)) {
+      strncpy(scheme, url, scheme_len);
+    }
+
+    int port = 80;
+    if (port_and_path[0] == ':') {
+      port = atoi(port_and_path + 1);
+    } else if (strncmp(scheme, "https://", 8) == 0) {
+      port = 443;
+    }
+
+    const char* dummy_host = "moonlight-ipv6-host";
+    rewritten_url = malloc(strlen(url) + strlen(dummy_host) + 1);
+    sprintf(rewritten_url, "%s%s%s", scheme, dummy_host, port_and_path);
+
+    resolve_string = malloc(strlen(dummy_host) + strlen(ipv6_raw) + 32);
+    sprintf(resolve_string, "%s:%d:%s", dummy_host, port, ipv6_raw);
+
+    resolve_list = curl_slist_append(NULL, resolve_string);
+    curl_easy_setopt(curl, CURLOPT_RESOLVE, resolve_list);
+    
+    real_url = rewritten_url;
+  }
+
+  curl_easy_setopt(curl, CURLOPT_URL, real_url);
 
   // Use the pinned certificate for HTTPS
   if (ppkstr != NULL) {
@@ -132,47 +168,7 @@ int http_request(const char* url, const char* ppkstr, PHTTP_DATA data) {
   if (res == CURLE_SSL_PINNEDPUBKEYNOTMATCH) {
     ret = GS_CERT_MISMATCH;
   } else if (res != CURLE_OK) {
-#ifdef __EMSCRIPTEN__
-  // Emscripten's built-in libcurl port uses a buggy regular expression to parse CURLOPT_URL.
-  // It fails to properly extract the host from bracketed IPv6 URLs (e.g. http://[fe80::1]:47989),
-  // instantly returning CURLE_COULDNT_RESOLVE_HOST without even trying to connect.
-  // To bypass this, we use EM_ASM to perform a native, synchronous XMLHttpRequest directly, 
-  // which handles IPv6 literals flawlessly.
-  printf("CURL failed (%s), falling back to EM_ASM XMLHttpRequest for %s\n", curl_easy_strerror(res), url);
-  char* response = (char*) EM_ASM_INT({
-    var url = UTF8ToString($0);
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', url, false);
-    try {
-      xhr.send();
-      if (xhr.status == 200 || xhr.status == 0) {
-        var respText = xhr.responseText || "";
-        var length = lengthBytesUTF8(respText) + 1;
-        var ptr = _malloc(length);
-        stringToUTF8(respText, ptr, length);
-        return ptr;
-      }
-    } catch(e) {
-      console.error("XMLHttpRequest failed for URL: " + url, e);
-    }
-    return 0;
-  }, url);
-
-  if (response == NULL) {
-    printf("EM_ASM XHR request failed for %s\n", url);
     ret = GS_FAILED;
-  } else {
-    if (data->memory != NULL) {
-      free(data->memory);
-    }
-    data->memory = response;
-    data->size = strlen(response);
-    printf("EM_ASM XHR request succeeded for %s\n", url);
-    ret = GS_OK;
-  }
-#else
-    ret = GS_FAILED;
-#endif
   } else if (data->memory == NULL) {
     ret = GS_OUT_OF_MEMORY;
   } else {
@@ -180,6 +176,9 @@ int http_request(const char* url, const char* ppkstr, PHTTP_DATA data) {
   }
   
 cleanup:
+  if (rewritten_url) free(rewritten_url);
+  if (resolve_string) free(resolve_string);
+  if (resolve_list) curl_slist_free_all(resolve_list);
   curl_easy_cleanup(curl);
   return ret;
 }

--- a/res/config.xml
+++ b/res/config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <widget xmlns:tizen="http://tizen.org/ns/widgets" xmlns="http://www.w3.org/ns/widgets" id="http://samsung.tv/MoonlightWasm" version="1.13.0" viewmodes="fullscreen">
     <access origin="*"></access>
-    <tizen:application id="MoonLight2.MoonlightWasm" package="MoonLight2" required_version="5.5" launch_mode="caller"/>
+    <tizen:application id="MoonLightS.MoonlightWasm" package="MoonLightS" required_version="5.5" launch_mode="caller"/>
     <content src="index.html"/>
     <description>Moonlight Game Streaming</description>
     <feature name="http://tizen.org/feature/screen.size.all"/>

--- a/res/config.xml
+++ b/res/config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <widget xmlns:tizen="http://tizen.org/ns/widgets" xmlns="http://www.w3.org/ns/widgets" id="http://samsung.tv/MoonlightWasm" version="1.13.0" viewmodes="fullscreen">
     <access origin="*"></access>
-    <tizen:application id="MoonLightS.MoonlightWasm" package="MoonLightS" required_version="5.5" launch_mode="caller"/>
+    <tizen:application id="MoonLight2.MoonlightWasm" package="MoonLight2" required_version="5.5" launch_mode="caller"/>
     <content src="index.html"/>
     <description>Moonlight Game Streaming</description>
     <feature name="http://tizen.org/feature/screen.size.all"/>

--- a/wasm/main.cpp
+++ b/wasm/main.cpp
@@ -528,8 +528,9 @@ MessageResult stopStream() {
   return g_Instance->StopStream();
 }
 
-void toggleStats() {
+MessageResult toggleStats() {
   g_Instance->TogglePerformanceStats();
+  return MessageResult::Resolve();
 }
 
 void stun(int callbackId) {
@@ -544,8 +545,9 @@ void pair(int callbackId, std::string serverMajorVersion, std::string address, i
   g_Instance->Pair(callbackId, serverMajorVersion, address, httpPort, randomNumber);
 }
 
-void cancelRequest() {
+MessageResult cancelRequest() {
   g_Instance->CancelRequest();
+  return MessageResult::Resolve();
 }
 
 void wakeOnLan(int callbackId, std::string macAddress) {

--- a/wasm/main.cpp
+++ b/wasm/main.cpp
@@ -370,6 +370,16 @@ MessageResult MoonlightInstance::StopStream() {
   return MessageResult::Resolve();
 }
 
+extern "C" void http_cancel_request();
+
+MessageResult MoonlightInstance::CancelRequest() {
+  ClLogMessage("%s: Canceling any ongoing HTTP request...\n", __func__);
+  // Begin canceling the HTTP request
+  http_cancel_request();
+
+  return MessageResult::Resolve();
+}
+
 void MoonlightInstance::STUN_private(int callbackId) {
   unsigned int wanAddr;
   char addrStr[128] = {};
@@ -397,13 +407,6 @@ void MoonlightInstance::Pair_private(int callbackId, std::string serverMajorVers
   } else {
     PostPromiseMessage(callbackId, "reject", std::to_string(err));
   }
-}
-
-extern "C" void http_cancel_request();
-
-void MoonlightInstance::CancelRequest() {
-  ClLogMessage("%s: Canceling any ongoing HTTP request\n", __func__);
-  http_cancel_request();
 }
 
 void MoonlightInstance::Pair(int callbackId, std::string serverMajorVersion, std::string address, int httpPort, std::string randomNumber) {
@@ -528,9 +531,12 @@ MessageResult stopStream() {
   return g_Instance->StopStream();
 }
 
-MessageResult toggleStats() {
+MessageResult cancelRequest() {
+  return g_Instance->CancelRequest();
+}
+
+void toggleStats() {
   g_Instance->TogglePerformanceStats();
-  return MessageResult::Resolve();
 }
 
 void stun(int callbackId) {
@@ -543,11 +549,6 @@ void pair(int callbackId, std::string serverMajorVersion, std::string address, i
   }
   g_UniqueId = strdup(uniqueId.c_str());
   g_Instance->Pair(callbackId, serverMajorVersion, address, httpPort, randomNumber);
-}
-
-MessageResult cancelRequest() {
-  g_Instance->CancelRequest();
-  return MessageResult::Resolve();
 }
 
 void wakeOnLan(int callbackId, std::string macAddress) {
@@ -588,9 +589,9 @@ EMSCRIPTEN_BINDINGS(handle_message) {
   emscripten::value_object<MessageResult>("MessageResult").field("type", &MessageResult::type).field("ret", &MessageResult::ret);
   emscripten::function("startStream", &startStream);
   emscripten::function("stopStream", &stopStream);
+  emscripten::function("cancelRequest", &cancelRequest);
   emscripten::function("toggleStats", &toggleStats);
   emscripten::function("stun", &stun);
   emscripten::function("pair", &pair);
-  emscripten::function("cancelRequest", &cancelRequest);
   emscripten::function("wakeOnLan", &wakeOnLan);
 }

--- a/wasm/moonlight_wasm.hpp
+++ b/wasm/moonlight_wasm.hpp
@@ -95,9 +95,10 @@ class MoonlightInstance {
     bool disableWarnings, bool performanceStats);
   MessageResult StopStream();
 
+  MessageResult CancelRequest();
+
   void STUN(int callbackId);
   void Pair(int callbackId, std::string serverMajorVersion, std::string address, int httpPort, std::string randomNumber);
-  void CancelRequest();
   void WakeOnLan(int callbackId, std::string macAddress);
 
   virtual ~MoonlightInstance();
@@ -295,7 +296,9 @@ MessageResult startStream(std::string host, int httpPort, std::string width, std
   bool disableWarnings, bool performanceStats);
 MessageResult stopStream();
 
-MessageResult toggleStats();
+MessageResult cancelRequest();
+
+void toggleStats();
 void stun(int callbackId);
 void pair(int callbackId, std::string serverMajorVersion, std::string address, int httpPort, std::string randomNumber, std::string uniqueId);
 void wakeOnLan(int callbackId, std::string macAddress);

--- a/wasm/moonlight_wasm.hpp
+++ b/wasm/moonlight_wasm.hpp
@@ -295,7 +295,7 @@ MessageResult startStream(std::string host, int httpPort, std::string width, std
   bool disableWarnings, bool performanceStats);
 MessageResult stopStream();
 
-void toggleStats();
+MessageResult toggleStats();
 void stun(int callbackId);
 void pair(int callbackId, std::string serverMajorVersion, std::string address, int httpPort, std::string randomNumber, std::string uniqueId);
 void wakeOnLan(int callbackId, std::string macAddress);

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -328,6 +328,7 @@ function beginBackgroundPollingOfHost(host) {
     if (hostCell) {
       hostCell.classList.add('host-cell-inactive');
     }
+    updateHostStatusIndicator(host);
 
     // Start background polling to detect when the host comes back online
     activePolls[host.serverUid] = window.setInterval(function() {
@@ -337,6 +338,7 @@ function beginBackgroundPollingOfHost(host) {
         } else {
           if (hostCell) hostCell.classList.add('host-cell-inactive');
         }
+        updateHostStatusIndicator(returnedHost);
       });
     }, 5000);
   });

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -219,8 +219,6 @@ function delayedNavigation(callback) {
 }
 
 function beginBackgroundPollingOfHost(host) {
-  // Assign methods of NvHTTP to the host object
-  Object.assign(host, NvHTTP.prototype);
 
   // Refresh server info before attempting to start background polling of the host
   host.refreshServerInfo().then(function(ret) {
@@ -270,6 +268,27 @@ function beginBackgroundPollingOfHost(host) {
     }
   }, function(failedRefreshInfo) {
     console.error('%c[index.js, beginBackgroundPollingOfHost]', 'color: green;', 'Error: Failed to refresh server info! Returned error was: ' + failedRefreshInfo + '! Failed server was: ' + '\n', host, '\n' + host.toString()); // Logging both object (for console) and toString-ed object (for text logs)
+    
+    // Set host to offline and clear the app list cache
+    host.online = false;
+    host._memCachedApplist = null;
+
+    // Update the UI to show the host as offline
+    var hostCell = document.querySelector('#host-' + host.serverUid);
+    if (hostCell) {
+      hostCell.classList.add('host-cell-inactive');
+    }
+
+    // Start background polling to detect when the host comes back online
+    activePolls[host.serverUid] = window.setInterval(function() {
+      host.pollServer(function(returnedHost) {
+        if (returnedHost.online) {
+          if (hostCell) hostCell.classList.remove('host-cell-inactive');
+        } else {
+          if (hostCell) hostCell.classList.add('host-cell-inactive');
+        }
+      });
+    }, 5000);
   });
 }
 
@@ -1000,11 +1019,13 @@ function addHostToGrid(host, ismDNSDiscovered) {
 // Function to correctly update and store the valid MAC address of the host in IndexedDB
 function updateMacAddress(host) {
   getData('hosts', function(previousValue) {
-    hosts = previousValue.hosts != null ? previousValue.hosts : {};
+    var dbHosts = previousValue.hosts != null ? previousValue.hosts : {};
     if (host.macAddress != '00:00:00:00:00:00') {
-      if (hosts[host.serverUid] && hosts[host.serverUid].macAddress != host.macAddress) {
-        console.log('%c[index.js, updateMacAddress]', 'color: green;', 'Updated MAC address for host ' + host.hostname + ' from ' + hosts[host.serverUid].macAddress + ' to ' + host.macAddress);
-        hosts[host.serverUid].macAddress = host.macAddress;
+      if (dbHosts[host.serverUid] && dbHosts[host.serverUid].macAddress != host.macAddress) {
+        console.log('%c[index.js, updateMacAddress]', 'color: green;', 'Updated MAC address for host ' + host.hostname + ' from ' + dbHosts[host.serverUid].macAddress + ' to ' + host.macAddress);
+        if (hosts[host.serverUid]) {
+          hosts[host.serverUid].macAddress = host.macAddress;
+        }
         saveHosts();
       }
     }
@@ -2101,7 +2122,7 @@ function showApps(host) {
   $('#wasmSpinnerMessage').text('Loading Apps...');
 
   // Remove all game container elements from the game grid and from any other div elements
-  $('#game-grid .game-container').remove();
+  $('#game-grid').empty();
   $('div.game-container').remove();
 
   setTimeout(() => {
@@ -3709,6 +3730,7 @@ function loadHTTPCertsCb() {
           revivedHost.externalIP = hosts[hostUID].externalIP;
           revivedHost.hostname = hosts[hostUID].hostname;
           revivedHost.ppkstr = hosts[hostUID].ppkstr;
+          hosts[hostUID] = revivedHost;
           addHostToGrid(revivedHost);
         }
         startPollingHosts();

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -241,6 +241,15 @@ function updateHostStatusIndicator(host) {
 }
 
 function beginBackgroundPollingOfHost(host) {
+  // Clear any existing polling interval for this host before starting a new one.
+  // Without this, every call to beginBackgroundPollingOfHost (e.g. on each navigation
+  // back to the host view) would leak the old setInterval, causing multiple overlapping
+  // poll loops that corrupt the _pollCompletionCallbacks deduplication guard and
+  // prevent the host from ever recovering to the online state.
+  if (activePolls[host.serverUid]) {
+    window.clearInterval(activePolls[host.serverUid]);
+    delete activePolls[host.serverUid];
+  }
 
   // Refresh server info before attempting to start background polling of the host
   host.refreshServerInfo().then(function(ret) {
@@ -295,10 +304,24 @@ function beginBackgroundPollingOfHost(host) {
     }
   }, function(failedRefreshInfo) {
     console.error('%c[index.js, beginBackgroundPollingOfHost]', 'color: green;', 'Error: Failed to refresh server info! Returned error was: ' + failedRefreshInfo + '! Failed server was: ' + '\n', host, '\n' + host.toString()); // Logging both object (for console) and toString-ed object (for text logs)
-    
+
     // Set host to offline and clear the app list cache
     host.online = false;
     host._memCachedApplist = null;
+
+    // Reset poll state so that recovery polls from the interval below start with
+    // a clean slate. Without this, stale _pollCompletionCallbacks entries from
+    // previous (leaked) intervals can block the deduplication guard and prevent
+    // pollServer from ever starting a new poll.
+    // Note: resetting _consecutivePollFailures to 0 here is always safe. If the
+    // host was previously online, this counter was already 0 (it is reset to 0 on
+    // every successful poll). Online *recovery* (host.online = true) is set
+    // unconditionally in pollServer's success callback regardless of this counter;
+    // the counter only gates the *offline* direction (host.online = false after
+    // >= 2 consecutive failures inside pollServer), so resetting it here does not
+    // interfere with future offline detection either.
+    host._consecutivePollFailures = 0;
+    host._pollCompletionCallbacks = [];
 
     // Update the UI to show the host as offline
     var hostCell = document.querySelector('#host-' + host.serverUid);
@@ -379,6 +402,11 @@ function showHostsMode() {
 
   Navigation.start();
   Navigation.pop();
+  // Stop any existing polls before starting new ones to prevent setInterval leaks.
+  // Without this, navigating back to the host view multiple times accumulates
+  // duplicate polling intervals for each host, which causes race conditions in
+  // _pollCompletionCallbacks and prevents the host from recovering to online.
+  stopPollingHosts();
   startPollingHosts();
 }
 

--- a/wasm/platform/messages.js
+++ b/wasm/platform/messages.js
@@ -12,9 +12,9 @@ const SyncFunctions = {
   // no parameters
   'stopRequest': (...args) => Module.stopStream(...args),
   // no parameters
-  'toggleStats': (...args) => Module.toggleStats(...args),
-  // no parameters
   'cancelRequest': (...args) => Module.cancelRequest(...args),
+  // no parameters
+  'toggleStats': (...args) => Module.toggleStats(...args),
 };
 
 const AsyncFunctions = {

--- a/wasm/static/js/utils.js
+++ b/wasm/static/js/utils.js
@@ -150,26 +150,33 @@ NvHTTP.prototype = {
     return this.isNvidiaServerSoftware ? '0123456789ABCDEF' : this.clientUid;
   },
 
+  _openUrlWithTimeout: function(url, ppkstr) {
+    return Promise.race([
+      sendMessage('openUrl', [url, ppkstr, false]),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout retrieving server info')), 5000))
+    ]).catch(error => {
+      if (error && error.message === 'Timeout retrieving server info') {
+        sendMessage('cancelRequest', []);
+        throw -1;
+      }
+      throw error;
+    });
+  },
+
   // Refreshes the server info using the base URL. This is useful for testing whether we can successfully ping a host at the base URL
   refreshServerInfo: function() {
     if (this.ppkstr == null) {
       // Use HTTP if we have no pinned cert
-      return sendMessage('openUrl', [
-        this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-      ]).then(function(retHttp) {
+      return this._openUrlWithTimeout(this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(retHttp) {
         this._parseServerInfo(retHttp);
       }.bind(this));
     }
     // Try HTTPS first
-    return sendMessage('openUrl', [
-      this._baseUrlHttps + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-    ]).then(function(ret) {
+    return this._openUrlWithTimeout(this._baseUrlHttps + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(ret) {
       if (!this._parseServerInfo(ret)) { // If that fails
         console.error('%c[utils.js, refreshServerInfo]', 'color: gray;', 'Error: Failed to parse server info from HTTPS, falling back to HTTP...');
         // Try HTTP as a failover. Useful to clients who aren't paired yet
-        return sendMessage('openUrl', [
-          this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-        ]).then(function(retHttp) {
+        return this._openUrlWithTimeout(this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(retHttp) {
           if (!this._parseServerInfo(retHttp)) {
             return Promise.reject("Failed to parse server info from HTTP");
           }
@@ -178,9 +185,7 @@ NvHTTP.prototype = {
     }.bind(this), function(error) {
       if (error == -100) { // GS_CERT_MISMATCH
         console.warn('%c[utils.js, refreshServerInfo]', 'color: gray;', 'Warning: Certificate mismatch. Retrying over HTTP...', this);
-        return sendMessage('openUrl', [
-          this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-        ]).then(function(retHttp) {
+        return this._openUrlWithTimeout(this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(retHttp) {
           if (!this._parseServerInfo(retHttp)) {
             return Promise.reject("Failed to parse server info from HTTP");
           }
@@ -195,24 +200,18 @@ NvHTTP.prototype = {
     var urlAddr = formatAddressForUrl(givenAddress);
     if (this.ppkstr == null) {
       // Use HTTP if we have no pinned cert
-      return sendMessage('openUrl', [
-        'http://' + urlAddr + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-      ]).then(function(retHttp) {
+      return this._openUrlWithTimeout('http://' + urlAddr + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(retHttp) {
         var parsed = this._parseServerInfo(retHttp);
         if (!parsed) return Promise.reject("Failed to parse server info from HTTP");
         return parsed;
       }.bind(this));
     }
     // Try HTTPS first
-    return sendMessage('openUrl', [
-      'https://' + urlAddr + ':' + this.httpsPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-    ]).then(function(ret) {
+    return this._openUrlWithTimeout('https://' + urlAddr + ':' + this.httpsPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(ret) {
       if (!this._parseServerInfo(ret)) { // If that fails
         console.error('%c[utils.js, refreshServerInfoAtAddress]', 'color: gray;', 'Error: Failed to parse server info from HTTPS, falling back to HTTP...');
         // Try HTTP as a failover. Useful to clients who aren't paired yet
-        return sendMessage('openUrl', [
-          'http://' + urlAddr + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-        ]).then(function(retHttp) {
+        return this._openUrlWithTimeout('http://' + urlAddr + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(retHttp) {
           var parsed = this._parseServerInfo(retHttp);
           if (!parsed) return Promise.reject("Failed to parse server info from HTTP");
           return parsed;
@@ -221,9 +220,7 @@ NvHTTP.prototype = {
     }.bind(this), function(error) {
       if (error == -100) { // GS_CERT_MISMATCH
         console.warn('%c[utils.js, refreshServerInfoAtAddress]', 'color: gray;', 'Warning: Certificate mismatch. Retrying over HTTP...', this);
-        return sendMessage('openUrl', [
-          'http://' + urlAddr + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-        ]).then(function(retHttp) {
+        return this._openUrlWithTimeout('http://' + urlAddr + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(retHttp) {
           var parsed = this._parseServerInfo(retHttp);
           if (!parsed) return Promise.reject("Failed to parse server info from HTTP");
           return parsed;
@@ -486,18 +483,9 @@ NvHTTP.prototype = {
   },
 
   getAppListWithCacheFlush: function() {
-    return Promise.race([
-      sendMessage('openUrl', [
-        this._baseUrlHttps + '/applist?' + this._buildUidStr(), this.ppkstr, false
-      ]),
-      new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout retrieving app list')), 5000))
-    ]).catch(error => {
-      // If it's our timeout error, instruct the C++ layer to abort the hung network request
-      if (error.message === 'Timeout retrieving app list') {
-        sendMessage('cancelRequest', []);
-      }
-      throw error;
-    }).then(function(ret) {
+    return sendMessage('openUrl', [
+      this._baseUrlHttps + '/applist?' + this._buildUidStr(), this.ppkstr, false
+    ]).then(function(ret) {
       $xml = this._parseXML(ret);
       $root = $xml.find('root');
 

--- a/wasm/static/js/utils.js
+++ b/wasm/static/js/utils.js
@@ -150,26 +150,33 @@ NvHTTP.prototype = {
     return this.isNvidiaServerSoftware ? '0123456789ABCDEF' : this.clientUid;
   },
 
+  _openUrlWithTimeout: function(url, ppkstr) {
+    return Promise.race([
+      sendMessage('openUrl', [url, ppkstr, false]),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout retrieving server info')), 5000))
+    ]).catch(error => {
+      if (error && error.message === 'Timeout retrieving server info') {
+        sendMessage('cancelRequest', []);
+        throw -1;
+      }
+      throw error;
+    });
+  },
+
   // Refreshes the server info using the base URL. This is useful for testing whether we can successfully ping a host at the base URL
   refreshServerInfo: function() {
     if (this.ppkstr == null) {
       // Use HTTP if we have no pinned cert
-      return sendMessage('openUrl', [
-        this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-      ]).then(function(retHttp) {
+      return this._openUrlWithTimeout(this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(retHttp) {
         this._parseServerInfo(retHttp);
       }.bind(this));
     }
     // Try HTTPS first
-    return sendMessage('openUrl', [
-      this._baseUrlHttps + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-    ]).then(function(ret) {
+    return this._openUrlWithTimeout(this._baseUrlHttps + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(ret) {
       if (!this._parseServerInfo(ret)) { // If that fails
         console.error('%c[utils.js, refreshServerInfo]', 'color: gray;', 'Error: Failed to parse server info from HTTPS, falling back to HTTP...');
         // Try HTTP as a failover. Useful to clients who aren't paired yet
-        return sendMessage('openUrl', [
-          this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-        ]).then(function(retHttp) {
+        return this._openUrlWithTimeout(this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(retHttp) {
           if (!this._parseServerInfo(retHttp)) {
             return Promise.reject("Failed to parse server info from HTTP");
           }
@@ -178,9 +185,7 @@ NvHTTP.prototype = {
     }.bind(this), function(error) {
       if (error == -100) { // GS_CERT_MISMATCH
         console.warn('%c[utils.js, refreshServerInfo]', 'color: gray;', 'Warning: Certificate mismatch. Retrying over HTTP...', this);
-        return sendMessage('openUrl', [
-          this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-        ]).then(function(retHttp) {
+        return this._openUrlWithTimeout(this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(retHttp) {
           if (!this._parseServerInfo(retHttp)) {
             return Promise.reject("Failed to parse server info from HTTP");
           }
@@ -195,24 +200,18 @@ NvHTTP.prototype = {
     var urlAddr = formatAddressForUrl(givenAddress);
     if (this.ppkstr == null) {
       // Use HTTP if we have no pinned cert
-      return sendMessage('openUrl', [
-        'http://' + urlAddr + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-      ]).then(function(retHttp) {
+      return this._openUrlWithTimeout('http://' + urlAddr + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(retHttp) {
         var parsed = this._parseServerInfo(retHttp);
         if (!parsed) return Promise.reject("Failed to parse server info from HTTP");
         return parsed;
       }.bind(this));
     }
     // Try HTTPS first
-    return sendMessage('openUrl', [
-      'https://' + urlAddr + ':' + this.httpsPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-    ]).then(function(ret) {
+    return this._openUrlWithTimeout('https://' + urlAddr + ':' + this.httpsPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(ret) {
       if (!this._parseServerInfo(ret)) { // If that fails
         console.error('%c[utils.js, refreshServerInfoAtAddress]', 'color: gray;', 'Error: Failed to parse server info from HTTPS, falling back to HTTP...');
         // Try HTTP as a failover. Useful to clients who aren't paired yet
-        return sendMessage('openUrl', [
-          'http://' + urlAddr + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-        ]).then(function(retHttp) {
+        return this._openUrlWithTimeout('http://' + urlAddr + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(retHttp) {
           var parsed = this._parseServerInfo(retHttp);
           if (!parsed) return Promise.reject("Failed to parse server info from HTTP");
           return parsed;
@@ -221,9 +220,7 @@ NvHTTP.prototype = {
     }.bind(this), function(error) {
       if (error == -100) { // GS_CERT_MISMATCH
         console.warn('%c[utils.js, refreshServerInfoAtAddress]', 'color: gray;', 'Warning: Certificate mismatch. Retrying over HTTP...', this);
-        return sendMessage('openUrl', [
-          'http://' + urlAddr + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
-        ]).then(function(retHttp) {
+        return this._openUrlWithTimeout('http://' + urlAddr + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr).then(function(retHttp) {
           var parsed = this._parseServerInfo(retHttp);
           if (!parsed) return Promise.reject("Failed to parse server info from HTTP");
           return parsed;
@@ -490,7 +487,7 @@ NvHTTP.prototype = {
       sendMessage('openUrl', [
         this._baseUrlHttps + '/applist?' + this._buildUidStr(), this.ppkstr, false
       ]),
-      new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout retrieving app list')), 5000))
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Timeout retrieving app list')), 10000))
     ]).catch(error => {
       // If it's our timeout error, instruct the C++ layer to abort the hung network request
       if (error.message === 'Timeout retrieving app list') {

--- a/wasm/static/js/utils.js
+++ b/wasm/static/js/utils.js
@@ -176,12 +176,8 @@ NvHTTP.prototype = {
         }.bind(this));
       }
     }.bind(this), function(error) {
-      if (error == -100 || error == -1) { // GS_CERT_MISMATCH or GS_FAILED (EM_ASM fallback HTTPS rejection)
-        if (error == -100) {
-          console.warn('%c[utils.js, refreshServerInfo]', 'color: gray;', 'Warning: Certificate mismatch. Retrying over HTTP...', this);
-        } else {
-          console.warn('%c[utils.js, refreshServerInfo]', 'color: gray;', 'Warning: HTTPS failure. Retrying over HTTP...', this);
-        }
+      if (error == -100) { // GS_CERT_MISMATCH
+        console.warn('%c[utils.js, refreshServerInfo]', 'color: gray;', 'Warning: Certificate mismatch. Retrying over HTTP...', this);
         return sendMessage('openUrl', [
           this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
         ]).then(function(retHttp) {
@@ -223,12 +219,8 @@ NvHTTP.prototype = {
         }.bind(this));
       }
     }.bind(this), function(error) {
-      if (error == -100 || error == -1) { // GS_CERT_MISMATCH or GS_FAILED (EM_ASM fallback HTTPS rejection)
-        if (error == -100) {
-          console.warn('%c[utils.js, refreshServerInfoAtAddress]', 'color: gray;', 'Warning: Certificate mismatch. Retrying over HTTP...', this);
-        } else {
-          console.warn('%c[utils.js, refreshServerInfoAtAddress]', 'color: gray;', 'Warning: HTTPS failure. Retrying over HTTP...', this);
-        }
+      if (error == -100) { // GS_CERT_MISMATCH
+        console.warn('%c[utils.js, refreshServerInfoAtAddress]', 'color: gray;', 'Warning: Certificate mismatch. Retrying over HTTP...', this);
         return sendMessage('openUrl', [
           'http://' + urlAddr + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
         ]).then(function(retHttp) {
@@ -671,12 +663,8 @@ NvHTTP.prototype = {
           if (error.message === 'Timeout during pairchallenge') {
             console.warn('%c[utils.js, pair]', 'color: gray;', 'Warning: HTTPS request timed out, canceling C++ HTTP request');
             sendMessage('cancelRequest', []);
-            throw error;
           }
-          console.warn('%c[utils.js, pair]', 'color: gray;', 'HTTPS pair challenge failed (' + error + '). Retrying over HTTP...');
-          return sendMessage('openUrl', [
-            this._baseUrlHttp + '/pair?uniqueid=' + this.getUid() + '&devicename=roth&updateState=1&phrase=pairchallenge', this.ppkstr, false
-          ]);
+          throw error;
         }.bind(this)).then(function(ret) {
           $xml = this._parseXML(ret);
           this.paired = $xml.find('paired').html() == '1';

--- a/wasm/static/js/utils.js
+++ b/wasm/static/js/utils.js
@@ -161,7 +161,9 @@ NvHTTP.prototype = {
         return sendMessage('openUrl', [
           this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
         ]).then(function(retHttp) {
-          this._parseServerInfo(retHttp);
+          if (!this._parseServerInfo(retHttp)) {
+            return Promise.reject("Failed to parse server info from HTTP");
+          }
         }.bind(this));
       }
     }.bind(this), function(error) {
@@ -171,9 +173,12 @@ NvHTTP.prototype = {
         return sendMessage('openUrl', [
           this._baseUrlHttp + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
         ]).then(function(retHttp) {
-          this._parseServerInfo(retHttp);
+          if (!this._parseServerInfo(retHttp)) {
+            return Promise.reject("Failed to parse server info from HTTP");
+          }
         }.bind(this));
       }
+      return Promise.reject(error);
     }.bind(this));
   },
 
@@ -184,7 +189,9 @@ NvHTTP.prototype = {
       return sendMessage('openUrl', [
         'http://' + givenAddress + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
       ]).then(function(retHttp) {
-        return this._parseServerInfo(retHttp);
+        var parsed = this._parseServerInfo(retHttp);
+        if (!parsed) return Promise.reject("Failed to parse server info from HTTP");
+        return parsed;
       }.bind(this));
     }
     // Try HTTPS first
@@ -197,7 +204,9 @@ NvHTTP.prototype = {
         return sendMessage('openUrl', [
           'http://' + givenAddress + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
         ]).then(function(retHttp) {
-          return this._parseServerInfo(retHttp);
+          var parsed = this._parseServerInfo(retHttp);
+          if (!parsed) return Promise.reject("Failed to parse server info from HTTP");
+          return parsed;
         }.bind(this));
       }
     }.bind(this), function(error) {
@@ -207,9 +216,12 @@ NvHTTP.prototype = {
         return sendMessage('openUrl', [
           'http://' + givenAddress + ':' + this.httpPort + '/serverinfo?' + this._buildUidStr(), this.ppkstr, false
         ]).then(function(retHttp) {
-          return this._parseServerInfo(retHttp);
+          var parsed = this._parseServerInfo(retHttp);
+          if (!parsed) return Promise.reject("Failed to parse server info from HTTP");
+          return parsed;
         }.bind(this));
       }
+      return Promise.reject(error);
     }.bind(this));
   },
 
@@ -258,6 +270,7 @@ NvHTTP.prototype = {
     }.bind(this), function() {
       if (++this._consecutivePollFailures >= 2) {
         this.online = false;
+        this._memCachedApplist = null;
       }
 
       // Call all pending completion callbacks

--- a/wasm/static/js/utils.js
+++ b/wasm/static/js/utils.js
@@ -254,6 +254,11 @@ NvHTTP.prototype = {
 
     // Check if a stream session is already in progress
     if (isInGame === true) {
+      // Drain callbacks to avoid permanently blocking the deduplication guard
+      var completion;
+      while ((completion = this._pollCompletionCallbacks.pop())) {
+        completion(this); // Executes the callback so the caller isn't left hanging
+      }
       // Do not initiate any server polls while a streaming session is already in progress
       return;
     }

--- a/wasm/static/js/utils.js
+++ b/wasm/static/js/utils.js
@@ -300,25 +300,39 @@ NvHTTP.prototype = {
 
   // Initially pings the server to try and figure out if it's routable by any means
   selectServerAddress: function(onSuccess, onFailure) {
-    // TODO: Deduplicate the addresses
-    this.refreshServerInfoAtAddress(this.address).then(function(successPrevAddr) {
-      onSuccess(this.address);
-    }.bind(this), function(successPrevAddr) {
-      this.refreshServerInfoAtAddress(this.hostname + '.local').then(function(successLocal) {
-        onSuccess(this.hostname + '.local');
-      }.bind(this), function(failureLocal) {
-        this.refreshServerInfoAtAddress(this.externalIP).then(function(successExternal) {
-          onSuccess(this.externalIP);
-        }.bind(this), function(failureExternal) {
-          this.refreshServerInfoAtAddress(this.userEnteredAddress).then(function(successUserEntered) {
-            onSuccess(this.userEnteredAddress);
-          }.bind(this), function(failureUserEntered) {
-            console.error('%c[utils.js, selectServerAddress]', 'color: gray;', 'Error: Failed to contact the ' + this.hostname + '!', this);
-            onFailure();
-          }.bind(this));
-        }.bind(this));
+    // Build a deduplicated, validated list of candidate addresses to try in order.
+    var seen = {};
+    var candidates = [];
+
+    var addCandidate = function(addr) {
+      if (addr && !seen[addr]) { // skip empty strings AND duplicates
+        seen[addr] = true;
+        candidates.push(addr);
+      }
+    };
+
+    addCandidate(this.address);
+    // Only append '.local' if the hostname doesn't already end with it
+    var localSuffix = this.hostname.endsWith('.local') ? this.hostname : this.hostname + '.local';
+    addCandidate(localSuffix);
+    addCandidate(this.externalIP);
+    addCandidate(this.userEnteredAddress);
+
+    var tryNext = function(index) {
+      if (index >= candidates.length) {
+        console.error('%c[utils.js, selectServerAddress]', 'color: gray;', 'Error: Failed to contact the ' + this.hostname + '!', this);
+        onFailure();
+        return;
+      }
+      var addr = candidates[index];
+      this.refreshServerInfoAtAddress(addr).then(function() {
+        onSuccess(addr);
+      }.bind(this), function() {
+        tryNext.call(this, index + 1);
       }.bind(this));
-    }.bind(this));
+    }.bind(this);
+
+    tryNext(0);
   },
 
   toString: function() {

--- a/wasm/static/js/utils.js
+++ b/wasm/static/js/utils.js
@@ -255,6 +255,11 @@ NvHTTP.prototype = {
     // Check if a stream session is already in progress
     if (isInGame === true) {
       // Do not initiate any server polls while a streaming session is already in progress
+      // Drain callbacks to avoid permanently blocking the deduplication guard
+      var completion;
+      while ((completion = this._pollCompletionCallbacks.pop())) {
+        completion(this); // Executes the callback so the caller isn't left hanging
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where the application would fail to clear its memory-cached app list and correctly update its internal "offline" state when Moonlight's host PC (Sunshine/GameStream) was closed or unreachable. Users would still be falsely presented with their cached apps after the host disconnected. 

It also completely re-architects how IPv6 addresses are handled, replacing the flawed JavaScript network fallback with a robust native C implementation, fixing infinite pairing loops, and resolving fatal application hangs caused by IPC timeouts.

## Root Causes & Fixes
This bug was the result of a compounding series of architectural issues across `index.js`, `utils.js`, `http.c`, and the WASM bridge that caused silent failures, split-brain state, and network deadlocks:

### 1. Native IPv6 Support & Infinite Unpairing Loop Fix
* **Why it was happening**: Previous versions of the app relied on an `EM_ASM` JavaScript `XMLHttpRequest` fallback (PR #86) to bypass Emscripten's buggy bracketed IPv6 URL parser (`http://[fe80::1]:47989`). However, Tizen's browser strictly blocks synchronous XHR calls to HTTPS endpoints with self-signed certs. The code attempted to bypass this by falling back to pure HTTP. Since Sunshine's HTTP port is unencrypted and cannot verify client certificates, it always returns `paired: 0`. Moonlight received this, matched the Server UID, and mistakenly updated existing paired hosts as "unpaired", creating an infinite pairing loop over IPv6 that prevented users from ever launching a game.
* **The Fix**: Completely removed the Javascript XHR fallback (`EM_ASM`) and dynamic HTTP retries. Instead, we implemented a purely native C workaround in `libgamestream/http.c`. When an IPv6 literal is detected, the C code strips the brackets, rewrites the URL using a dummy hostname (`moonlight-ipv6-host`), and instructs `libcurl` to map it directly to the raw IPv6 address using `CURLOPT_RESOLVE`. This bypasses Emscripten's regex bug natively, allowing `libcurl` to securely connect over HTTPS and safely ignore self-signed certificate errors (`CURLOPT_SSL_VERIFYPEER = 0`), completely eliminating the infinite unpairing loop.
* **Note: This logic seamlessly handles user-entered IPv6 addresses both with and without brackets (`[]`).** If a user types a raw IPv6 address without brackets, the `formatAddressForUrl()` function in `utils.js` detects the colons and automatically wraps it in brackets to create a valid URL. Once that URL reaches the native C networking layer, our new `CURLOPT_RESOLVE` logic safely catches those brackets, strips them back out, and routes the packet to the correct raw IP.

### 2. C++ WASM IPC Timeout & Hanging Fix
* **Why it was happening**: When network requests timed out (e.g. attempting to pair or poll an unreachable host), JavaScript dispatched a `sendMessage('cancelRequest')` to the C++ WebAssembly layer. However, the C++ `cancelRequest()` and `toggleStats()` functions were declared as `void` and did not return a `MessageResult`. This broke the internal WASM messaging loop (`HandleMessage`), causing the application to hang indefinitely.
* **The Fix**: Modified `main.cpp` and `moonlight_wasm.hpp` so that `cancelRequest()` and `toggleStats()` return `MessageResult::Resolve()`, properly satisfying the asynchronous IPC lifecycle and preventing the UI from locking up during network timeouts.

### 3. Swallowed Promise Rejections in Networking Functions
* **Why it was happening**: In `utils.js`, `refreshServerInfo` and `refreshServerInfoAtAddress` had error handlers (`.then(..., function(error) {})`) that attempted to catch specific errors (like `-100` for cert mismatch). However, when they caught normal network failures (like `-1` for connection refused), they neglected to return a new `Promise.reject(error)`. In JavaScript, if a `.catch` or rejection handler doesn't explicitly throw or reject, the promise chain resolves as *successful*.
* **What it broke**: The background poller pinged offline hosts but interpreted the swallowed errors as "successes", continually resetting its offline counter (`this._consecutivePollFailures = 0`) instead of registering the host as disconnected.
* **The Fix**: Added explicit `return Promise.reject(error)` and `return Promise.reject("Failed to parse server info from HTTP")` for HTTP fallbacks to ensure network failures cascade correctly.

### 4. Split-Brain Host Objects in Memory
* **Why it was happening**: During startup, `index.js` loaded hosts from IndexedDB as raw JSON objects and revived them into `NvHTTP` class instances (`revivedHost`) to build the UI. However, it forgot to update the global `hosts` array with these new instances.
* **What it broke**: The UI was tied to the fully-functional `revivedHost`, while the background poller iterated over the global `hosts` array, which still contained raw JSON. The background poller ended up modifying a "phantom" object that was completely disconnected from what the user saw on screen. Even if the poller detected an offline state, the UI's copy of the host was never updated.
* **The Fix**: Added `hosts[hostUID] = revivedHost;` in `loadHTTPCertsCb` during startup so both the UI and background tasks share the same object in memory.

### 5. Silent Background Clobbering in `updateMacAddress`
* **Why it was happening**: To patch the aforementioned crash (`host.refreshServerInfo is not a function`) caused by the poller running on JSON objects, the original author had added a hack: `Object.assign(host, NvHTTP.prototype)` inside `beginBackgroundPollingOfHost`. But the *real* reason the crash happened was because `updateMacAddress(host)` in `index.js` had a catastrophic bug: it asynchronously loaded from IndexedDB using `getData('hosts')` and overwrote the ENTIRE global `hosts` array with raw JSON objects, silently destroying any `NvHTTP` instances that were in memory.
* **The Fix**: Removed the `Object.assign` hack. Fixed `updateMacAddress` by scoping its database read to a local variable `var dbHosts = ...` rather than overwriting the global `hosts` array.

### 6. Missing Offline Cache Clearing
* **The Fix**: Added `this._memCachedApplist = null;` inside the failure branch of `pollServer` in `utils.js` (when `_consecutivePollFailures >= 2`) so the app list cache is guaranteed to be purged when a host genuinely drops offline. Added immediate UI updates and cache clearing to `beginBackgroundPollingOfHost`. 
   
## Console Errors Fixed:
* `Uncaught TypeError: host.refreshServerInfo is not a function`: Caused by `updateMacAddress` quietly destroying `NvHTTP` class instances in the background.
* Incorrectly reporting `App list requested successfully` in the console despite preceding CURL connection failures.

---

## Type of Change

Please select the relevant option(s):
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Please describe how you tested your changes:
- TV model: UN43T5300AGXZD
- Tizen version: 5.5
- Steps to test the change:

1. Open the Moonlight Tizen app and ensure you have a paired host (PC running Sunshine/GameStream).
2. With the host PC online, click the host in the UI and verify that the app list loads properly.
3. Press Back to return to the main host selection screen.
4. Close Sunshine (or turn off the host PC) to force it to go offline.
5. Wait ~5-10 seconds for the background poller to detect the offline status. 
6. Click the offline host.
7. Verify that you are immediately blocked from entering the app list and a "Failed to connect to the host..." toast message appears.
8. Turn Sunshine back on.
9. Wait for the background poller to detect the host is online again (the host UI element should become active).
10. Click the host and verify the app list loads successfully with fresh data.

---

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have tested my changes locally on my device
- [X] I have made corresponding changes to the documentation
- [X] I have added comments, particularly in hard-to-understand areas
- [X] No unexpected issues or behavior were introduced
- [X] The project builds successfully with no warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
