### PR TITLE
fix: Prevent gamepads from dropping after a short period of time due to Tizen timestamp bug

### DIFF
--- a/wasm/gamepad.cpp
+++ b/wasm/gamepad.cpp
@@ -167,6 +167,9 @@ void MoonlightInstance::PollGamepads() {
   // Prevent repeated trigger while the button combo is held down
   static bool comboTriggered = false;
 
+  // Track valid gamepads that had a non-zero timestamp at least once
+  static bool isRealGamepad[32] = { false };
+
   // Iterate through connected gamepads and process their input
   for (int gamepadID = 0; gamepadID < numGamepads; ++gamepadID) {
     emscripten_sample_gamepad_data();
@@ -177,10 +180,17 @@ void MoonlightInstance::PollGamepads() {
     const auto result = emscripten_get_gamepad_status(gamepadID, &gamepad);
     if (result != EMSCRIPTEN_RESULT_SUCCESS || !gamepad.connected) {
       // Not connected
+      if (gamepadID < 32) {
+        isRealGamepad[gamepadID] = false;
+      }
       continue;
     }
 
-    if (gamepad.timestamp == 0) {
+    if (gamepadID < 32 && gamepad.timestamp != 0) {
+      isRealGamepad[gamepadID] = true;
+    }
+
+    if (gamepad.timestamp == 0 && (gamepadID >= 32 || !isRealGamepad[gamepadID])) {
       // On some platforms, Tizen returns "connected" gamepads that really 
       // aren't, so timestamp stays at zero. To work around this, we'll only
       // count gamepads that have a non-zero timestamp in our controller index.

--- a/wasm/static/js/utils.js
+++ b/wasm/static/js/utils.js
@@ -40,6 +40,7 @@ function cryptoRand(upper_bound) {
   return array[0] % upper_bound;
 }
 
+var _realGamepads = new Set();
 function getConnectedGamepadMask() {
   var count = 0;
   var mask = 0;
@@ -53,10 +54,15 @@ function getConnectedGamepadMask() {
 
       if (!gamepad.connected) {
         // Not connected
+        _realGamepads.delete(gamepad.index);
         continue;
       }
 
-      if (gamepad.timestamp == 0) {
+      if (gamepad.timestamp !== 0) {
+        _realGamepads.add(gamepad.index);
+      }
+
+      if (gamepad.timestamp === 0 && !_realGamepads.has(gamepad.index)) {
         // On some platforms, Tizen returns "connected" gamepads that really 
         // aren't, so timestamp stays at zero. To work around this, we'll only
         // count gamepads that have a non-zero timestamp in our controller index.


### PR DESCRIPTION
### Description
Fixes #103 where gamepads (especially USB dongle controllers) would freeze and stop sending input to the host PC after ~10 minutes of streaming, requiring a full app or TV restart.

### Cause
Previously, a workaround was introduced to ignore "ghost" or phantom gamepads by discarding any inputs where `gamepad.timestamp == 0`.

However, due to a bug/quirk in Tizen OS's WebKit implementation (likely related to USB power-saving or inactivity timeouts), perfectly valid controllers will inexplicably start reporting a `timestamp` of `0` after a short period of use, even though they continue to report valid axis and button data. Because of the `timestamp == 0` check, the C++ WebAssembly loop would silently drop their inputs mid-stream. 

### Solution

- Introduced a state tracking mechanism (`isRealGamepad` array in `gamepad.cpp` and `_realGamepads` Set in `utils.js`).
- When a controller connects with a non-zero timestamp, it is now persistently flagged as a "valid" gamepad.
- If Tizen later resets the timestamp to `0`, the application remembers the controller is real and continues processing its inputs.
- Pure "ghost" gamepads (which always have a timestamp of `0` from the moment they are enumerated) continue to be correctly ignored.

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Please describe how you tested your changes:
- TV model: UN43T5300AGXZD
- Tizen version: 5.5
- Steps to test the change:

Include screenshots or logs if applicable.

---

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have tested my changes locally on my device
- [X] I have made corresponding changes to the documentation
- [X] I have added comments, particularly in hard-to-understand areas
- [X] No unexpected issues or behavior were introduced
- [X] The project builds successfully with no warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
