### PR TITLE
chore: Optimize Docker build caching for Tizen SDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS base
+FROM ubuntu:22.04 AS sdk
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
@@ -28,6 +28,8 @@ RUN aria2c -x 5 -s 5 -o web-cli_Tizen_Studio_6.1_ubuntu-64.bin 'https://download
 RUN chmod a+x web-cli_Tizen_Studio_6.1_ubuntu-64.bin
 RUN ./web-cli_Tizen_Studio_6.1_ubuntu-64.bin --accept-license /home/moonlight/tizen-studio
 ENV PATH=/home/moonlight/tizen-studio/tools/ide/bin:/home/moonlight/tizen-studio/tools:${PATH}
+
+FROM sdk AS base
 
 # Prepare the Tizen certificate and security profiles for signing the application package
 RUN tizen certificate \


### PR DESCRIPTION
## Description

This change improves the Docker build times by leveraging multi-stage layer caching. 

By separating the heavy Tizen Studio installation into its own `sdk` stage (`FROM ubuntu:22.04 AS sdk`) and starting the subsequent steps in a new stage (`FROM sdk AS base`), we lock the SDK setup into a reusable cache layer, completely bypassing the slow process of re-downloading and re-installing the Tizen Studio SDK for downstream edits.

---

## Type of Change

Please select the relevant option(s):
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [X] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
