### PR TITLE
fix: Prevent multiple system info calls during startup

### DIFF
--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -3527,15 +3527,15 @@ function loadUserDataCb() {
     const savedLanguagePreference = (previousValue && previousValue['languagePreference']) || 'auto';
     // Update the language field based on the stored value
     $('#selectLanguage').attr('data-value', savedLanguagePreference).data('value', savedLanguagePreference);
+    // Register loadSystemInfo to re-run every time the language changes
+    if (window.i18n && typeof window.i18n.onRefresh === 'function') {
+      window.i18n.onRefresh(loadSystemInfo);
+    }
     // Apply the stored language preference if the i18n object is available
     if (window.i18n && typeof window.i18n.applyLanguagePreference === 'function') {
       window.i18n.applyLanguagePreference(savedLanguagePreference).catch((error) => {
         console.error('%c[index.js, loadUserDataCb]', 'color: green;', 'Error: Failed to apply stored language: ' + error);
       });
-    }
-    // Register loadSystemInfo to re-run every time the language changes
-    if (window.i18n && typeof window.i18n.onRefresh === 'function') {
-      window.i18n.onRefresh(loadSystemInfo);
     }
   });
 
@@ -3874,7 +3874,6 @@ function onWindowLoad() {
 
   initSamsungKeys();
   initSpecialKeys();
-  loadSystemInfo();
   loadUserData();
 }
 

--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -3527,10 +3527,6 @@ function loadUserDataCb() {
     const savedLanguagePreference = (previousValue && previousValue['languagePreference']) || 'auto';
     // Update the language field based on the stored value
     $('#selectLanguage').attr('data-value', savedLanguagePreference).data('value', savedLanguagePreference);
-    // Register loadSystemInfo to re-run every time the language changes
-    if (window.i18n && typeof window.i18n.onRefresh === 'function') {
-      window.i18n.onRefresh(loadSystemInfo);
-    }
     // Apply the stored language preference if the i18n object is available
     if (window.i18n && typeof window.i18n.applyLanguagePreference === 'function') {
       window.i18n.applyLanguagePreference(savedLanguagePreference).catch((error) => {
@@ -3858,6 +3854,10 @@ function loadHTTPCertsCb() {
           addHostToGrid(revivedHost);
         }
         startPollingHosts();
+        // Register loadSystemInfo to re-run every time the language changes
+        if (window.i18n && typeof window.i18n.onRefresh === 'function') {
+          window.i18n.onRefresh(loadSystemInfo);
+        }
         console.log('%c[index.js, loadHTTPCertsCb]', 'color: green;', 'Loading previously connected hosts...');
         // Start subnet scanning silently in the background after hosts are fully loaded
         setTimeout(() => {
@@ -3874,6 +3874,7 @@ function onWindowLoad() {
 
   initSamsungKeys();
   initSpecialKeys();
+  loadSystemInfo();
   loadUserData();
 }
 


### PR DESCRIPTION
## Description

This PR addresses an issue where `loadSystemInfo()` was being called three times consecutively during application startup.

### Root Cause
Previously, the startup flow triggered redundant calls due to the following sequence:
1. `onWindowLoad()` directly called `loadSystemInfo()` (1st call).
2. `onWindowLoad()` called `loadUserData()`, which eventually invoked `loadUserDataCb()`.
3. Inside `loadUserDataCb()`, `window.i18n.applyLanguagePreference()` was called, which triggered `refreshUI()`.
4. Because `window.i18n.onRefresh(loadSystemInfo)` was registered *after* `applyLanguagePreference()`, async resolution caused `refreshUI()` to iterate through its callbacks and fire `loadSystemInfo()` repeatedly (2nd and 3rd calls).

### Fix
- Removed the direct `loadSystemInfo()` call from `onWindowLoad()`.
- Inside `loadUserDataCb()`, reordered the `window.i18n.onRefresh(loadSystemInfo)` registration to occur **before** calling `applyLanguagePreference()`. 

This ensures that `loadSystemInfo()` now fires exactly once, precisely when the i18n system completes initialization and triggers `refreshUI()`.

---

## Type of Change

Please select the relevant option(s):
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [X] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Pre-existing behavior, not introduced by PR #94.
