### PR TITLE
fix: Prevent memory-cached app list from persisting across application restarts

### DIFF
--- a/wasm/platform/index.js
+++ b/wasm/platform/index.js
@@ -3830,6 +3830,7 @@ function loadHTTPCertsCb() {
         for (var hostUID in hosts) { // Programmatically add each new host
           var revivedHost = new NvHTTP(hosts[hostUID].address, myUniqueid, hosts[hostUID].userEnteredAddress, hosts[hostUID].macAddress);
           Object.assign(revivedHost, hosts[hostUID]);
+          revivedHost._memCachedApplist = null; // Prevent using the app list cache from a previous session
           revivedHost.httpPort = hosts[hostUID].httpPort || ((hosts[hostUID].httpsPort || 47984) + 5);
           revivedHost.httpsPort = hosts[hostUID].httpsPort || (revivedHost.httpPort - 5);
           revivedHost.externalPort = hosts[hostUID].externalPort || revivedHost.httpPort;


### PR DESCRIPTION
## Description
When adding or removing apps on the host PC (via Sunshine or GFE) while Moonlight is closed, Moonlight continues to show the old app list upon restart. It never attempts to update the list, as it continuously serves the data cached from the previous session.

## Root Cause
The `_memCachedApplist` inside the `NvHTTP` instance is supposed to start as `null` by design. However, it was being serialized into `localStorage` by `saveHosts()`. Upon application startup, `Object.assign()` (introduced by PR https://github.com/brightcraft/moonlight-tizen/pull/90) copies all properties from the saved JSON object back into the `NvHTTP` instance, effectively restoring the old cache and bypassing the intended `getAppListWithCacheFlush()` call.

## Solution
Explicitly set `revivedHost._memCachedApplist = null;` immediately after `Object.assign()` during startup. This ensures the app list starts empty at the beginning of each session, forcing an update on the first fetch while keeping the caching mechanism intact for the remainder of the session.

---

## Type of Change

Please select the relevant option(s):
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Performance improvement
- [ ] Localization / translation
- [ ] Code cleanup / refactoring
- [ ] Documentation update
- [ ] Other (please explain)

---

## Testing

Provide your test environment and describe how you tested your changes. If applicable, include screenshots or videos demonstrating your changes.

**Test Environment:**
- TV model: UN43T5300AGXZD
- Tizen version: 5.5

**Test Steps:**
1. Open Moonlight, pair with a host, and load the apps.
2. Close Moonlight.
3. Add or remove an app on the host PC (via Sunshine or GFE).
4. Re-open Moonlight and open the PC host.
5. Verify that a network request is made and the app list accurately reflects the changes made while Moonlight was closed.
6. Return to the host list and re-open the PC host. Verify that it loads instantly from the cache.

---

## Checklist

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have avoided unnecessary changes to third-party dependencies
- [X] I have updated documentation where applicable
- [X] I have added comments where necessary, especially in complex areas
- [X] I have tested my changes locally on my device
- [X] I have checked for potential regressions or unexpected behavior
- [X] The project builds successfully without warnings or errors
- [X] This PR focuses on a single feature or fix without unrelated changes

---

## Additional Notes

Any other information that reviewers should know, including limitations, concerns, or context about the change.
